### PR TITLE
fixed sats conversion fetching point

### DIFF
--- a/lightning-chama/src/app/userdashboard/chama/createchama/nextcreatechama/page.tsx
+++ b/lightning-chama/src/app/userdashboard/chama/createchama/nextcreatechama/page.tsx
@@ -4,6 +4,7 @@ import { ArrowLeft } from "lucide-react";
 import { Navbar } from "@/components/Navbar";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
+import { useBitcoinKesRate } from "@/hooks/useBitcoinKesRate";
 
 const CONTRIBUTION_FREQUENCIES = [
   { label: "Daily", value: "DAILY", days: 1 },
@@ -33,60 +34,15 @@ export default function CreateChamaForm() {
   } | null>(null);
 
   const [loading, setLoading] = useState(false);
-  const [exchangeRate, setExchangeRate] = useState<number | null>(null);
-  const [loadingRate, setLoadingRate] = useState(true);
-  const [lastFetched, setLastFetched] = useState<number | null>(null);
+  const { exchangeRate, loadingRate, lastFetched } = useBitcoinKesRate();
 
   // 1 Bitcoin = 100,000,000 Satoshis
   const SATOSHIS_PER_BTC = 100000000;
-  // Cache the rate for 5 minutes (300,000 milliseconds)
-  const CACHE_DURATION_MS = 5 * 60 * 1000;
 
   useEffect(() => {
     const saved = localStorage.getItem("createChamaStep1");
     if (saved) setStep1Data(JSON.parse(saved));
   }, []);
-
-  // Fetch exchange rate with simple caching
-  useEffect(() => {
-    const fetchExchangeRate = async () => {
-      // Check if we have a recently cached rate
-      if (lastFetched && Date.now() - lastFetched < CACHE_DURATION_MS) {
-        console.log("Using cached exchange rate.");
-        setLoadingRate(false);
-        return;
-      }
-
-      try {
-        setLoadingRate(true);
-        console.log("Fetching new exchange rate from CoinGecko...");
-        // *** Using 'kes'  ***
-        const response = await fetch(
-          "https://api.coingecko.com/api/v3/simple/price?ids=bitcoin&vs_currencies=kes"
-        );
-        if (!response.ok) {
-            throw new Error(`API responded with status: ${response.status}`);
-        }
-        const data = await response.json();
-        // *** Accessing 'kes' property ***
-        if (data.bitcoin && data.bitcoin.kes) {
-          setExchangeRate(data.bitcoin.kes);
-          setLastFetched(Date.now()); // Update the last fetched timestamp
-        }
-      } catch (error) {
-        console.error("Failed to fetch exchange rate:", error);
-        // Fallback to a default rate if API fails and no rate exists
-        if (!exchangeRate) {
-           // Using a more recent approximate rate
-           setExchangeRate(11500000); 
-        }
-      } finally {
-        setLoadingRate(false);
-      }
-    };
-
-    fetchExchangeRate();
-  }, []); // Empty dependency array means this runs once on mount
 
   // Convert KES to Satoshis
   const convertKesToSatoshis = (kesAmount: number): number => {

--- a/lightning-chama/src/app/userdashboard/contribute/[id]/page.tsx
+++ b/lightning-chama/src/app/userdashboard/contribute/[id]/page.tsx
@@ -4,6 +4,7 @@ import React, { useEffect, useState, useMemo } from 'react';
 import { ArrowLeft, User, CheckCircle, XCircle, Wallet, AlertCircle, X, Loader2, ChevronDown, ChevronUp, Zap, Bell, MoreVertical } from 'lucide-react';
 import { useParams, useRouter } from 'next/navigation';
 import SatsAmount from '@/components/SatsAmount';
+import { useBitcoinKesRate } from '@/hooks/useBitcoinKesRate';
 
 // Helper to format time ago
 const timeAgo = (date: string) => {
@@ -68,38 +69,9 @@ export default function ChamasContribution() {
     error: ''
   });
 
-  const [exchangeRate, setExchangeRate] = useState<number | null>(null);
-  const [loadingRate, setLoadingRate] = useState(true);
-  const [lastFetched, setLastFetched] = useState<number | null>(null);
-  const CACHE_DURATION_MS = 5 * 60 * 1000;
+  const { exchangeRate, loadingRate } = useBitcoinKesRate();
 
   const currentUserRef = useMemo(() => localStorage.getItem('userReference'), []);
-  
-  // Exchange Rate Logic
-  useEffect(() => {
-    const fetchExchangeRate = async () => {
-      if (lastFetched && Date.now() - lastFetched < CACHE_DURATION_MS) {
-        setLoadingRate(false);
-        return;
-      }
-      try {
-        setLoadingRate(true);
-        const response = await fetch("https://api.coingecko.com/api/v3/simple/price?ids=bitcoin&vs_currencies=kes");
-        if (!response.ok) throw new Error(`API responded with status: ${response.status}`);
-        const data = await response.json();
-        if (data.bitcoin && data.bitcoin.kes) {
-          setExchangeRate(data.bitcoin.kes);
-          setLastFetched(Date.now());
-        }
-      } catch (error) {
-        console.error("Failed to fetch exchange rate:", error);
-        if (!exchangeRate) setExchangeRate(11500000);
-      } finally {
-        setLoadingRate(false);
-      }
-    };
-    fetchExchangeRate();
-  }, [exchangeRate, lastFetched, CACHE_DURATION_MS]);
 
   const convertSatsToKes = (sats: number): number => {
     if (!exchangeRate) return 0;

--- a/lightning-chama/src/app/userdashboard/contribute/page.tsx
+++ b/lightning-chama/src/app/userdashboard/contribute/page.tsx
@@ -19,6 +19,7 @@ import {
 import { Navbar } from '@/components/Navbar';
 import Link from 'next/link';
 import SatsAmount from '@/components/SatsAmount';
+import { useBitcoinKesRate } from '@/hooks/useBitcoinKesRate';
 
 // --- Types ---
 interface Wallet {
@@ -92,10 +93,7 @@ export default function ChamasContribution() {
   });
 
   // Exchange Rate State
-  const [exchangeRate, setExchangeRate] = useState<number | null>(null);
-  const [loadingRate, setLoadingRate] = useState(true);
-  const [lastFetched, setLastFetched] = useState<number | null>(null);
-  const CACHE_DURATION_MS = 5 * 60 * 1000;
+  const { exchangeRate, loadingRate } = useBitcoinKesRate();
 
   // --- Helpers ---
   
@@ -135,34 +133,6 @@ export default function ChamasContribution() {
   }, [cycles]);
 
   // --- Effects ---
-
-  // 1. Fetch Exchange Rate
-  useEffect(() => {
-    const fetchExchangeRate = async () => {
-      if (lastFetched && Date.now() - lastFetched < CACHE_DURATION_MS) {
-        setLoadingRate(false);
-        return;
-      }
-      try {
-        setLoadingRate(true);
-        const response = await fetch(
-          "https://api.coingecko.com/api/v3/simple/price?ids=bitcoin&vs_currencies=kes"
-        );
-        if (!response.ok) throw new Error(`API status: ${response.status}`);
-        const data = await response.json();
-        if (data.bitcoin && data.bitcoin.kes) {
-          setExchangeRate(data.bitcoin.kes);
-          setLastFetched(Date.now());
-        }
-      } catch (error) {
-        console.error("Rate fetch error:", error);
-        if (!exchangeRate) setExchangeRate(11500000);
-      } finally {
-        setLoadingRate(false);
-      }
-    };
-    fetchExchangeRate();
-  }, [CACHE_DURATION_MS, exchangeRate, lastFetched]);
 
   // 2. Fetch User Wallets
   useEffect(() => {

--- a/lightning-chama/src/app/userdashboard/page.tsx
+++ b/lightning-chama/src/app/userdashboard/page.tsx
@@ -11,6 +11,7 @@ import chama0 from '@/assets/chama0.svg';
 import chama1 from '@/assets/chama1.svg';
 import chama2 from '@/assets/chama2.svg';
 import chama3 from '@/assets/chama3.svg';
+import { useBitcoinKesRate } from '@/hooks/useBitcoinKesRate';
 
 type OnRampResponse = {
   message?: string;
@@ -117,12 +118,7 @@ export default function Dashboard() {
   const [walletDetailsCopied, setWalletDetailsCopied] = useState('');
   
   // Exchange rate state
-  const [exchangeRate, setExchangeRate] = useState<number | null>(null);
-  const [loadingRate, setLoadingRate] = useState(true);
-  const [lastFetched, setLastFetched] = useState<number | null>(null);
-  
-  // Cache the rate for 5 minutes (300,000 milliseconds)
-  const CACHE_DURATION_MS = 5 * 60 * 1000;
+  const { exchangeRate, loadingRate, lastFetched } = useBitcoinKesRate();
   const SATS_PER_BTC = 100_000_000;
 
   const fetchWallets = async () => {
@@ -160,44 +156,6 @@ export default function Dashboard() {
       setLoadingWallets(false);
     }
   };
-
-  // Fetch exchange rate with caching
-  useEffect(() => {
-    const fetchExchangeRate = async () => {
-      // Check if we have a recently cached rate
-      if (lastFetched && Date.now() - lastFetched < CACHE_DURATION_MS) {
-        console.log("Using cached exchange rate.");
-        setLoadingRate(false);
-        return;
-      }
-
-      try {
-        setLoadingRate(true);
-        console.log("Fetching new exchange rate from CoinGecko...");
-        const response = await fetch(
-          "https://api.coingecko.com/api/v3/simple/price?ids=bitcoin&vs_currencies=kes"
-        );
-        if (!response.ok) {
-          throw new Error(`API responded with status: ${response.status}`);
-        }
-        const data = await response.json();
-        if (data.bitcoin && data.bitcoin.kes) {
-          setExchangeRate(data.bitcoin.kes);
-          setLastFetched(Date.now());
-        }
-      } catch (error) {
-        console.error("Failed to fetch exchange rate:", error);
-        // Fallback to a default rate if API fails and no rate exists
-        if (!exchangeRate) {
-          setExchangeRate(11500000); // Fallback rate
-        }
-      } finally {
-        setLoadingRate(false);
-      }
-    };
-
-    fetchExchangeRate();
-  }, []);
 
   useEffect(() => {
     const fetchChamas = async () => {

--- a/lightning-chama/src/app/userdashboard/wallet/page.tsx
+++ b/lightning-chama/src/app/userdashboard/wallet/page.tsx
@@ -7,6 +7,7 @@ import { Navbar } from '@/components/Navbar';
 import BalanceHero from '@/components/BalanceHero';
 import SatsAmount from '@/components/SatsAmount';
 import Image from 'next/image';
+import { useBitcoinKesRate } from '@/hooks/useBitcoinKesRate';
 
 // --- TYPES ---
 
@@ -41,8 +42,6 @@ type Invoice = {
   paidAt?: string;
 };
 
-const CACHE_DURATION_MS = 5 * 60 * 1000;
-
 const WalletPage = () => {
   // --- STATE ---
 
@@ -62,10 +61,8 @@ const WalletPage = () => {
   const [walletDetailsCopied, setWalletDetailsCopied] = useState<string | null>(null);
   const [techDetailsExpanded, setTechDetailsExpanded] = useState(false);
 
-  const [exchangeRate, setExchangeRate] = useState<number | null>(null);
-  const [loadingRate, setLoadingRate] = useState(true);
-  const [lastFetched, setLastFetched] = useState<number | null>(null);
-  
+  const { exchangeRate, loadingRate } = useBitcoinKesRate();
+
   // New states for invoice filtering
   const [statusFilter, setStatusFilter] = useState<string>('ALL');
   const [searchQuery, setSearchQuery] = useState('');
@@ -224,34 +221,6 @@ const WalletPage = () => {
   };
 
   // --- EFFECTS ---
-
-  useEffect(() => {
-    const fetchExchangeRate = async () => {
-      if (lastFetched && Date.now() - lastFetched < CACHE_DURATION_MS) {
-        setLoadingRate(false);
-        return;
-      }
-      try {
-        setLoadingRate(true);
-        const response = await fetch(
-          "https://api.coingecko.com/api/v3/simple/price?ids=bitcoin&vs_currencies=kes"
-        );
-        if (!response.ok) throw new Error(`API status: ${response.status}`);
-        const data = await response.json();
-        if (data.bitcoin && data.bitcoin.kes) {
-          setExchangeRate(data.bitcoin.kes);
-          setLastFetched(Date.now());
-        }
-      } catch (error) {
-        console.error("Rate fetch error:", error);
-        if (!exchangeRate) setExchangeRate(11500000);
-      } finally {
-        setLoadingRate(false);
-      }
-    };
-    fetchExchangeRate();
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
 
   useEffect(() => {
     const fetchWallets = async () => {

--- a/lightning-chama/src/hooks/useBitcoinKesRate.ts
+++ b/lightning-chama/src/hooks/useBitcoinKesRate.ts
@@ -19,15 +19,24 @@ export const useBitcoinKesRate = () => {
 
       try {
         setLoadingRate(true);
-        const response = await fetch(
-          'https://api.coingecko.com/api/v3/simple/price?ids=bitcoin&vs_currencies=kes'
-        );
+        // CoinGecko doesn't support KES as a vs_currency, so BTC/KES has to be
+        // derived from BTC/USD and a separate USD/KES FX rate.
+        const [btcResponse, fxResponse] = await Promise.all([
+          fetch('https://api.coingecko.com/api/v3/simple/price?ids=bitcoin&vs_currencies=usd'),
+          fetch('https://open.er-api.com/v6/latest/USD'),
+        ]);
 
-        if (!response.ok) throw new Error(`API responded with status: ${response.status}`);
+        if (!btcResponse.ok) throw new Error(`CoinGecko API responded with status: ${btcResponse.status}`);
+        if (!fxResponse.ok) throw new Error(`FX API responded with status: ${fxResponse.status}`);
 
-        const data = await response.json();
-        if (data.bitcoin?.kes) {
-          setExchangeRate(data.bitcoin.kes);
+        const btcData = await btcResponse.json();
+        const fxData = await fxResponse.json();
+
+        const btcUsd = btcData.bitcoin?.usd;
+        const usdKes = fxData.rates?.KES;
+
+        if (btcUsd && usdKes) {
+          setExchangeRate(btcUsd * usdKes);
           setLastFetched(Date.now());
         }
       } catch (error) {


### PR DESCRIPTION

The current conversion fetches the data from coingecko, but coin gecko doesnt support KES, hence rendering the amount 0 in KES

solution
The shared `useBitcoinKesRate` hook (lightning-chama/src/hooks/useBitcoinKesRate.ts) now fetches BTC - USD from CoinGecko and USD - KES from a free FX API (open.er-api.com) in parallel, then multiplies them to get the BTC/KES rate.

This simplifies calculation from the user side they are able to see the amount of sats in KES accurately without having to convert manually.