### PR TITLE
bundled updates

### DIFF
--- a/chamavault/src/main/java/com/dada_labs_two/chamavault/chama/constants/MembershipStatus.java
+++ b/chamavault/src/main/java/com/dada_labs_two/chamavault/chama/constants/MembershipStatus.java
@@ -2,5 +2,7 @@ package com.dada_labs_two.chamavault.chama.constants;
 
 public enum MembershipStatus {
     ACTIVE,
-    PENDING
+    PENDING,
+    SUSPENDED,
+    REMOVED
 }

--- a/chamavault/src/main/java/com/dada_labs_two/chamavault/chama/controllers/ChamaController.java
+++ b/chamavault/src/main/java/com/dada_labs_two/chamavault/chama/controllers/ChamaController.java
@@ -12,6 +12,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -24,7 +25,7 @@ public class ChamaController {
     private final ChamaService chamaService;
 
     @PostMapping
-    public ResponseEntity<Chama> initiateChamaCreation(@RequestBody CreateChamaDTO chama) {
+    public ResponseEntity<Chama> initiateChamaCreation(@jakarta.validation.Valid @RequestBody CreateChamaDTO chama) {
         return ResponseEntity.ok(chamaService.createChama(chama));
     }
 
@@ -46,7 +47,9 @@ public class ChamaController {
     }
 
     @PostMapping("/create/invite")
-    public ResponseEntity<ChamaInviteDTO>  createChamaInvite(@RequestBody CreateChamaInviteDTO invite) {
+    public ResponseEntity<ChamaInviteDTO>  createChamaInvite(@AuthenticationPrincipal com.dada_labs_two.chamavault.users.models.User user,
+                                                              @jakarta.validation.Valid @RequestBody CreateChamaInviteDTO invite) {
+        invite.setAdminPhone(user.getMsisdn());
         return ResponseEntity.ok(toChamaInviteDTO(chamaService.generateChamaInvite(invite)));
     }
 

--- a/chamavault/src/main/java/com/dada_labs_two/chamavault/chama/dtos/ChamaGroupWalletDTO.java
+++ b/chamavault/src/main/java/com/dada_labs_two/chamavault/chama/dtos/ChamaGroupWalletDTO.java
@@ -20,6 +20,7 @@ public class ChamaGroupWalletDTO {
     private String walletPurpose;
     private WalletType walletType;
     private Long balanceSats;
+    private Long targetAmountSats;
     private Long lnBitsbalanceSats;
     private Boolean active;
     private Map<String, String> lightning = new HashMap<>();

--- a/chamavault/src/main/java/com/dada_labs_two/chamavault/chama/dtos/CreateChamaDTO.java
+++ b/chamavault/src/main/java/com/dada_labs_two/chamavault/chama/dtos/CreateChamaDTO.java
@@ -34,5 +34,9 @@ public class CreateChamaDTO {
     @NotNull(message = "contributionAmount is required") //make this a required field
     private Long contributionAmount;
     private Long dailyLimitSats;
-}
 
+    /** Optional. A group wallet is only provisioned when this is true. */
+    private Boolean createGroupWallet = false;
+    /** Required and positive when createGroupWallet is true. */
+    private Long groupWalletTargetAmountSats;
+}

--- a/chamavault/src/main/java/com/dada_labs_two/chamavault/chama/dtos/CreateChamaInviteDTO.java
+++ b/chamavault/src/main/java/com/dada_labs_two/chamavault/chama/dtos/CreateChamaInviteDTO.java
@@ -12,7 +12,7 @@ public class CreateChamaInviteDTO {
     @NotNull(message = "chamaReferenceId is a required field")
     private UUID chamaReferenceId;
 
-    @NotBlank(message = "adminPhone is required")
+    /** Populated from the authenticated principal; request values are ignored. */
     private String adminPhone;
 
     @NotNull(message = "specify if to join chama, member requires admin approval")
@@ -20,4 +20,7 @@ public class CreateChamaInviteDTO {
 
     @NotNull(message = "specify the open role in the chama")
     private ChamaRole role;
+
+    /** Defaults to chama.invites.expiry-days (7) and is capped by the service. */
+    private Integer expiryDays;
 }

--- a/chamavault/src/main/java/com/dada_labs_two/chamavault/chama/repositories/ChamaMemberRepository.java
+++ b/chamavault/src/main/java/com/dada_labs_two/chamavault/chama/repositories/ChamaMemberRepository.java
@@ -52,6 +52,9 @@ public interface ChamaMemberRepository extends JpaRepository<ChamaMember, UUID> 
 
     Optional<ChamaMember> findByUserAndChama(User user, Chama chama);
 
+    Optional<ChamaMember> findByChama_ChamaReferenceAndUser_UserReferenceAndStatus(
+            UUID chamaReference, UUID userReference, MembershipStatus status);
+
     Page<ChamaMember> findAllByChama_ChamaReferenceAndStatus(UUID chamaReference, MembershipStatus status, Pageable pageable);
 
     List<ChamaMember> findAllByChama_ChamaReferenceAndStatus(UUID chamaReference, MembershipStatus status);

--- a/chamavault/src/main/java/com/dada_labs_two/chamavault/chama/services/ChamaService.java
+++ b/chamavault/src/main/java/com/dada_labs_two/chamavault/chama/services/ChamaService.java
@@ -40,6 +40,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -51,6 +52,8 @@ import java.util.stream.Collectors;
 @RequiredArgsConstructor
 @Slf4j
 public class ChamaService {
+    @Value("${chama.invites.expiry-days:7}")
+    private int defaultInviteExpiryDays;
     private final ObjectMapper objectMapper;
     private final OpenAiService openAiService;
     private final GeminiService geminiService;
@@ -71,6 +74,10 @@ public class ChamaService {
 
     @Transactional
     public Chama createChama(CreateChamaDTO createChamaDTO) {
+        if (Boolean.TRUE.equals(createChamaDTO.getCreateGroupWallet()) &&
+                (createChamaDTO.getGroupWalletTargetAmountSats() == null || createChamaDTO.getGroupWalletTargetAmountSats() <= 0)) {
+            throw new IllegalArgumentException("groupWalletTargetAmountSats must be positive when createGroupWallet is true");
+        }
         User creator  = userRepository.findById(createChamaDTO.getCreatorId()).orElseThrow();
         // 1. Create Chama
         Chama chama = chamaRepository.save(
@@ -96,16 +103,19 @@ public class ChamaService {
                         .build()
         );
 
-        // 3. Create Group Wallet
-        Wallet wallet = walletRepository.save(
+        Wallet wallet = null;
+        if (Boolean.TRUE.equals(createChamaDTO.getCreateGroupWallet())) {
+            wallet = walletRepository.save(
                 Wallet.builder()
                         .walletType(WalletType.CHAMA_GROUP)
                         .ownerReference(chama.getChamaReference())
                         .balanceSats(0L)
+                        .targetAmountSats(createChamaDTO.getGroupWalletTargetAmountSats())
                         .chama(chama)
                         .active(true)
                         .build()
-        );
+                );
+        }
 
         // 4. Create Rules
         chamaRulesRepository.save(
@@ -119,6 +129,7 @@ public class ChamaService {
                         .build()
         );
 
+        if (wallet != null) {
         //5. Create Group lightning Wallet
         WalletResponse lw= lightningWalletService.createUserWallet(chama.getName());
         log.info("LW created user wallet: {}", lw);
@@ -140,6 +151,7 @@ public class ChamaService {
         wallet.setLightning(lightningMap);
         wallet.setWalletPurpose("General wallet for the chama");
         wallet = walletRepository.save(wallet);
+        }
 
         //6. Assign group lightning  address
         String lnUsername = chama.getName()
@@ -312,6 +324,7 @@ public class ChamaService {
                             .walletReference(w.getWalletReference())
                             .walletType(w.getWalletType())
                             .balanceSats(w.getBalanceSats())
+                            .targetAmountSats(w.getTargetAmountSats())
                             .lnBitsbalanceSats(w.getLnBitsbalanceSats())
                             .active(w.getActive())
                             .createdAt(w.getCreatedAt())
@@ -334,6 +347,13 @@ public class ChamaService {
         //check chama exists
         Chama chama = chamaRepository.findById(chamaInviteDTO.getChamaReferenceId()).orElseThrow(() ->
                 new RuntimeException("Chama reference not found"));
+        User inviter = userRepository.findByMsisdn(chamaInviteDTO.getAdminPhone()).orElseThrow();
+        chamaMemberRepository.findByChama_ChamaReferenceAndUser_UserReferenceAndStatus(
+                chama.getChamaReference(), inviter.getUserReference(), MembershipStatus.ACTIVE)
+                .orElseThrow(() -> new SecurityException("Only active chama members can create invites"));
+        int expiryDays = chamaInviteDTO.getExpiryDays() == null ? defaultInviteExpiryDays : chamaInviteDTO.getExpiryDays();
+        if (expiryDays < 1 || expiryDays > 90) throw new IllegalArgumentException("expiryDays must be between 1 and 90");
+        ZonedDateTime expiresAt = ZonedDateTime.now().plusDays(expiryDays);
 
         //generate invite code
         Code inviteCode = codeService.createCode(CodeDTO.builder()
@@ -341,7 +361,7 @@ public class ChamaService {
                         .active(true)
                         .description(chama.getDescription())
                         .ownerMsisdn(chamaInviteDTO.getAdminPhone())
-                        .expirationDate(ZonedDateTime.now().plusMonths(30))
+                        .expirationDate(expiresAt)
                 .build());
 
         ChamaInvite chamaInvite = chamaInviteRepository.save(ChamaInvite.builder()
@@ -351,14 +371,14 @@ public class ChamaService {
                         .requiresApproval(chamaInviteDTO.getRequiresApproval())
                         .used(false)
                         .paused(false)
-                        .expiresAt(ZonedDateTime.now().plusMonths(30))
+                        .expiresAt(expiresAt)
                 .build());
 
         profileActionService.createProfileActions(userRepository.findByMsisdn(chamaInviteDTO.getAdminPhone()).orElseThrow(),
                 Activity.COMPLETED,"create invite code",
                 "chama invite code created successfully", chama.getDescription(),
                 "[Admins]: Kindly note that the invite expires after "+ chamaInvite.getExpiresAt(),
-                ZonedDateTime.now().plusMonths(30));
+                expiresAt);
 
         //send notification
         profileActionService.notifyInviteCreated(

--- a/chamavault/src/main/java/com/dada_labs_two/chamavault/configs/GlobalExceptionHandler.java
+++ b/chamavault/src/main/java/com/dada_labs_two/chamavault/configs/GlobalExceptionHandler.java
@@ -9,6 +9,12 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 @ControllerAdvice
 public class GlobalExceptionHandler {
 
+    @ExceptionHandler(SecurityException.class)
+    public ResponseEntity<ApiError> handleSecurity(SecurityException ex) {
+        return new ResponseEntity<>(new ApiError(ex.getMessage(), "Forbidden", HttpStatus.FORBIDDEN.value()),
+                HttpStatus.FORBIDDEN);
+    }
+
     @ExceptionHandler(DataIntegrityViolationException.class)
     public ResponseEntity<ApiError> handleDataIntegrityViolation(DataIntegrityViolationException ex) {
         ApiError error = new ApiError(

--- a/chamavault/src/main/java/com/dada_labs_two/chamavault/contributions/controllers/GroupWalletContributionController.java
+++ b/chamavault/src/main/java/com/dada_labs_two/chamavault/contributions/controllers/GroupWalletContributionController.java
@@ -10,7 +10,8 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 import java.util.UUID;
 
-@RestController @RequiredArgsConstructor
+@RestController
+@RequiredArgsConstructor
 @RequestMapping("/chamas/{chamaId}/group-wallets/{walletId}/contributions")
 public class GroupWalletContributionController {
     private final GroupWalletContributionService service;

--- a/chamavault/src/main/java/com/dada_labs_two/chamavault/contributions/controllers/GroupWalletContributionController.java
+++ b/chamavault/src/main/java/com/dada_labs_two/chamavault/contributions/controllers/GroupWalletContributionController.java
@@ -1,0 +1,23 @@
+package com.dada_labs_two.chamavault.contributions.controllers;
+
+import com.dada_labs_two.chamavault.contributions.dtos.*;
+import com.dada_labs_two.chamavault.contributions.services.GroupWalletContributionService;
+import com.dada_labs_two.chamavault.users.models.User;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+import java.util.UUID;
+
+@RestController @RequiredArgsConstructor
+@RequestMapping("/chamas/{chamaId}/group-wallets/{walletId}/contributions")
+public class GroupWalletContributionController {
+    private final GroupWalletContributionService service;
+    @PostMapping
+    public ResponseEntity<GroupWalletContributionResponse> contribute(@PathVariable UUID chamaId,
+            @PathVariable UUID walletId, @AuthenticationPrincipal User user,
+            @Valid @RequestBody GroupWalletContributionRequest request) {
+        return ResponseEntity.ok(service.contribute(chamaId, walletId, user, request));
+    }
+}

--- a/chamavault/src/main/java/com/dada_labs_two/chamavault/contributions/dtos/GroupWalletContributionRequest.java
+++ b/chamavault/src/main/java/com/dada_labs_two/chamavault/contributions/dtos/GroupWalletContributionRequest.java
@@ -1,0 +1,10 @@
+package com.dada_labs_two.chamavault.contributions.dtos;
+
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+import java.util.UUID;
+
+public record GroupWalletContributionRequest(
+        @Min(value = 1, message = "amountSats must be positive") long amountSats,
+        @NotNull UUID fundingWalletReference) {
+}

--- a/chamavault/src/main/java/com/dada_labs_two/chamavault/contributions/dtos/GroupWalletContributionResponse.java
+++ b/chamavault/src/main/java/com/dada_labs_two/chamavault/contributions/dtos/GroupWalletContributionResponse.java
@@ -3,7 +3,16 @@ package com.dada_labs_two.chamavault.contributions.dtos;
 import java.time.ZonedDateTime;
 import java.util.UUID;
 
-public record GroupWalletContributionResponse(UUID contributionReference, UUID walletReference,
-        long amountSats, long totalContributionSats, Long targetAmountSats,
-        long remainingToTargetSats, String paymentReference, ZonedDateTime contributedAt) {
+public record GroupWalletContributionResponse(UUID contributionReference,
+                                              UUID walletReference,
+                                              long amountSats,
+                                              long totalContributionSats,
+                                              long targetAmountSats,
+                                              long remainingToTargetSats,
+                                              long platformFeeSats,
+                                              long totalChargedSats,
+                                              UUID feeRuleReference,
+                                              String paymentReference,
+                                              String feePaymentReference,
+                                              ZonedDateTime contributedAt) {
 }

--- a/chamavault/src/main/java/com/dada_labs_two/chamavault/contributions/dtos/GroupWalletContributionResponse.java
+++ b/chamavault/src/main/java/com/dada_labs_two/chamavault/contributions/dtos/GroupWalletContributionResponse.java
@@ -1,0 +1,9 @@
+package com.dada_labs_two.chamavault.contributions.dtos;
+
+import java.time.ZonedDateTime;
+import java.util.UUID;
+
+public record GroupWalletContributionResponse(UUID contributionReference, UUID walletReference,
+        long amountSats, long totalContributionSats, Long targetAmountSats,
+        long remainingToTargetSats, String paymentReference, ZonedDateTime contributedAt) {
+}

--- a/chamavault/src/main/java/com/dada_labs_two/chamavault/contributions/models/GroupWalletContribution.java
+++ b/chamavault/src/main/java/com/dada_labs_two/chamavault/contributions/models/GroupWalletContribution.java
@@ -1,0 +1,43 @@
+package com.dada_labs_two.chamavault.contributions.models;
+
+import com.dada_labs_two.chamavault.chama.models.Chama;
+import com.dada_labs_two.chamavault.users.models.User;
+import com.dada_labs_two.chamavault.wallets.models.Wallet;
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.CreationTimestamp;
+
+import java.time.ZonedDateTime;
+import java.util.UUID;
+
+@Entity
+@Table(name = "group_wallet_contributions", indexes = {
+        @Index(name = "idx_group_contribution_wallet", columnList = "wallet_reference"),
+        @Index(name = "idx_group_contribution_chama", columnList = "chama_reference")
+})
+@Getter @Setter @Builder @NoArgsConstructor @AllArgsConstructor
+public class GroupWalletContribution {
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID reference;
+
+    @ManyToOne(optional = false)
+    @JoinColumn(name = "chama_reference")
+    private Chama chama;
+
+    @ManyToOne(optional = false)
+    @JoinColumn(name = "wallet_reference")
+    private Wallet wallet;
+
+    @ManyToOne(optional = false)
+    @JoinColumn(name = "user_reference")
+    private User contributor;
+
+    @Column(nullable = false)
+    private Long amountSats;
+
+    private String externalReference;
+
+    @CreationTimestamp
+    private ZonedDateTime contributedAt;
+}

--- a/chamavault/src/main/java/com/dada_labs_two/chamavault/contributions/models/GroupWalletContribution.java
+++ b/chamavault/src/main/java/com/dada_labs_two/chamavault/contributions/models/GroupWalletContribution.java
@@ -35,6 +35,10 @@ public class GroupWalletContribution {
 
     @Column(nullable = false)
     private Long amountSats;
+    private Long platformFeeSats;
+
+    private UUID feeRuleReference;
+    private String feePaymentReference;
 
     private String externalReference;
 

--- a/chamavault/src/main/java/com/dada_labs_two/chamavault/contributions/repositories/ContributionCycleRepository.java
+++ b/chamavault/src/main/java/com/dada_labs_two/chamavault/contributions/repositories/ContributionCycleRepository.java
@@ -22,6 +22,7 @@ public interface ContributionCycleRepository extends JpaRepository<ContributionC
     List<ContributionCycle> findByStatusAndEndAtBefore(ContributionCycleStatus contributionCycleStatus, ZonedDateTime date);
 
     boolean existsByChamaAndStatus(Chama chama, ContributionCycleStatus contributionCycleStatus);
+    List<ContributionCycle> findByStatus(ContributionCycleStatus contributionCycleStatus);
 
     Page<ContributionCycle> findAllByChama(Pageable pageable, Chama chama);
 

--- a/chamavault/src/main/java/com/dada_labs_two/chamavault/contributions/repositories/GroupWalletContributionRepository.java
+++ b/chamavault/src/main/java/com/dada_labs_two/chamavault/contributions/repositories/GroupWalletContributionRepository.java
@@ -1,0 +1,8 @@
+package com.dada_labs_two.chamavault.contributions.repositories;
+
+import com.dada_labs_two.chamavault.contributions.models.GroupWalletContribution;
+import org.springframework.data.jpa.repository.JpaRepository;
+import java.util.UUID;
+
+public interface GroupWalletContributionRepository extends JpaRepository<GroupWalletContribution, UUID> {
+}

--- a/chamavault/src/main/java/com/dada_labs_two/chamavault/contributions/services/ContributionCycleService.java
+++ b/chamavault/src/main/java/com/dada_labs_two/chamavault/contributions/services/ContributionCycleService.java
@@ -47,7 +47,7 @@ public class ContributionCycleService {
     /* ============================
        Scheduler
      ============================ */
-    @Scheduled(cron = "0 */10 * * * *") // every 30 minutes
+    @Scheduled(cron = "0 */30 * * * *") // every 30 minutes
     @Transactional
     public void manageCycles() {
         closeExpiredCycles();

--- a/chamavault/src/main/java/com/dada_labs_two/chamavault/contributions/services/ContributionReminderService.java
+++ b/chamavault/src/main/java/com/dada_labs_two/chamavault/contributions/services/ContributionReminderService.java
@@ -1,0 +1,40 @@
+package com.dada_labs_two.chamavault.contributions.services;
+
+import com.dada_labs_two.chamavault.chama.constants.MembershipStatus;
+import com.dada_labs_two.chamavault.chama.models.ChamaMember;
+import com.dada_labs_two.chamavault.chama.repositories.ChamaMemberRepository;
+import com.dada_labs_two.chamavault.contributions.constants.ContributionCycleStatus;
+import com.dada_labs_two.chamavault.contributions.models.ContributionCycle;
+import com.dada_labs_two.chamavault.contributions.repositories.ContributionCycleRepository;
+import com.dada_labs_two.chamavault.users.services.ProfileActionService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+import java.time.ZonedDateTime;
+import java.util.Set;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+@Service @RequiredArgsConstructor
+public class ContributionReminderService {
+    private final ContributionCycleRepository cycleRepository;
+    private final ChamaMemberRepository memberRepository;
+    private final ProfileActionService notifications;
+    @Value("${chama.reminders.hours-before-due:24}") private long hoursBeforeDue;
+
+    @Scheduled(cron = "${chama.reminders.cron:0 0 8 * * *}")
+    public void remindOutstandingContributors() {
+        ZonedDateTime cutoff = ZonedDateTime.now().plusHours(hoursBeforeDue);
+        for (ContributionCycle cycle : cycleRepository.findByStatus(ContributionCycleStatus.ACTIVE)) {
+            if (cycle.getEndAt() == null || cycle.getEndAt().isAfter(cutoff)) continue;
+            Set<UUID> paid = cycle.getContributorWallets().stream().map(w -> w.getOwnerReference()).collect(Collectors.toSet());
+            for (ChamaMember member : memberRepository.findMembersByChamaAndStatus(
+                    cycle.getChama().getChamaReference(), MembershipStatus.ACTIVE)) {
+                if (!paid.contains(member.getUser().getUserReference())) {
+                    notifications.notifyContributionReminder(member.getUser(), cycle);
+                }
+            }
+        }
+    }
+}

--- a/chamavault/src/main/java/com/dada_labs_two/chamavault/contributions/services/GroupWalletContributionService.java
+++ b/chamavault/src/main/java/com/dada_labs_two/chamavault/contributions/services/GroupWalletContributionService.java
@@ -1,0 +1,61 @@
+package com.dada_labs_two.chamavault.contributions.services;
+
+import com.dada_labs_two.chamavault.chama.constants.MembershipStatus;
+import com.dada_labs_two.chamavault.chama.repositories.ChamaMemberRepository;
+import com.dada_labs_two.chamavault.contributions.dtos.*;
+import com.dada_labs_two.chamavault.contributions.models.GroupWalletContribution;
+import com.dada_labs_two.chamavault.contributions.repositories.GroupWalletContributionRepository;
+import com.dada_labs_two.chamavault.users.models.User;
+import com.dada_labs_two.chamavault.lightning.services.LightningWalletService;
+import com.dada_labs_two.chamavault.users.services.ProfileActionService;
+import com.dada_labs_two.chamavault.wallets.constants.WalletType;
+import com.dada_labs_two.chamavault.wallets.models.Wallet;
+import com.dada_labs_two.chamavault.wallets.repositories.WalletRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class GroupWalletContributionService {
+    private final ChamaMemberRepository memberRepository;
+    private final WalletRepository walletRepository;
+    private final GroupWalletContributionRepository contributionRepository;
+    private final ProfileActionService notifications;
+    private final LightningWalletService lightningWalletService;
+
+    @Transactional
+    public GroupWalletContributionResponse contribute(UUID chamaId, UUID walletId, User user,
+                                                       GroupWalletContributionRequest request) {
+        memberRepository.findByChama_ChamaReferenceAndUser_UserReferenceAndStatus(
+                chamaId, user.getUserReference(), MembershipStatus.ACTIVE)
+                .orElseThrow(() -> new SecurityException("Only active chama members can contribute"));
+        Wallet wallet = walletRepository.findActiveChamaWalletForUpdate(
+                walletId, chamaId, WalletType.CHAMA_GROUP)
+                .orElseThrow(() -> new IllegalArgumentException("Active group wallet not found"));
+        Wallet fundingWallet = walletRepository.findById(request.fundingWalletReference())
+                .filter(w -> user.getUserReference().equals(w.getOwnerReference()))
+                .filter(w -> Boolean.TRUE.equals(w.getActive()))
+                .orElseThrow(() -> new SecurityException("Funding wallet is not owned by the contributor"));
+        if (wallet.getLightning() == null || wallet.getLightning().get("inkey") == null ||
+                fundingWallet.getLightning() == null || fundingWallet.getLightning().get("adminkey") == null)
+            throw new IllegalStateException("Both wallets must have Lightning credentials");
+        String invoice = lightningWalletService.createInvoice(wallet.getLightning().get("inkey"),
+                request.amountSats(), "Contribution to " + wallet.getChama().getName());
+        String paymentReference = lightningWalletService.payInvoice(
+                fundingWallet.getLightning().get("adminkey"), invoice);
+        wallet.setBalanceSats(Math.addExact(wallet.getBalanceSats(), request.amountSats()));
+        walletRepository.save(wallet);
+        GroupWalletContribution saved = contributionRepository.save(GroupWalletContribution.builder()
+                .chama(wallet.getChama()).wallet(wallet).contributor(user)
+                .amountSats(request.amountSats()).externalReference(paymentReference).build());
+        long target = wallet.getTargetAmountSats() == null ? 0 : wallet.getTargetAmountSats();
+        notifications.notifyGroupWalletContribution(user, wallet.getChama(), request.amountSats(),
+                wallet.getBalanceSats(), wallet.getTargetAmountSats());
+        return new GroupWalletContributionResponse(saved.getReference(), walletId, request.amountSats(),
+                wallet.getBalanceSats(), wallet.getTargetAmountSats(), Math.max(0, target - wallet.getBalanceSats()),
+                paymentReference, saved.getContributedAt());
+    }
+}

--- a/chamavault/src/main/java/com/dada_labs_two/chamavault/contributions/services/GroupWalletContributionService.java
+++ b/chamavault/src/main/java/com/dada_labs_two/chamavault/contributions/services/GroupWalletContributionService.java
@@ -7,6 +7,9 @@ import com.dada_labs_two.chamavault.contributions.models.GroupWalletContribution
 import com.dada_labs_two.chamavault.contributions.repositories.GroupWalletContributionRepository;
 import com.dada_labs_two.chamavault.users.models.User;
 import com.dada_labs_two.chamavault.lightning.services.LightningWalletService;
+import com.dada_labs_two.chamavault.fees.services.FeeService;
+import com.dada_labs_two.chamavault.fees.dtos.FeeQuote;
+import com.dada_labs_two.chamavault.wallets.constants.TransactionCategory;
 import com.dada_labs_two.chamavault.users.services.ProfileActionService;
 import com.dada_labs_two.chamavault.wallets.constants.WalletType;
 import com.dada_labs_two.chamavault.wallets.models.Wallet;
@@ -25,37 +28,53 @@ public class GroupWalletContributionService {
     private final GroupWalletContributionRepository contributionRepository;
     private final ProfileActionService notifications;
     private final LightningWalletService lightningWalletService;
+    private final FeeService feeService;
 
     @Transactional
     public GroupWalletContributionResponse contribute(UUID chamaId, UUID walletId, User user,
-                                                       GroupWalletContributionRequest request) {
+                                                      GroupWalletContributionRequest request) {
         memberRepository.findByChama_ChamaReferenceAndUser_UserReferenceAndStatus(
-                chamaId, user.getUserReference(), MembershipStatus.ACTIVE)
+                        chamaId, user.getUserReference(), MembershipStatus.ACTIVE)
                 .orElseThrow(() -> new SecurityException("Only active chama members can contribute"));
+
         Wallet wallet = walletRepository.findActiveChamaWalletForUpdate(
-                walletId, chamaId, WalletType.CHAMA_GROUP)
+                        walletId, chamaId, WalletType.CHAMA_GROUP)
                 .orElseThrow(() -> new IllegalArgumentException("Active group wallet not found"));
+
         Wallet fundingWallet = walletRepository.findById(request.fundingWalletReference())
                 .filter(w -> user.getUserReference().equals(w.getOwnerReference()))
                 .filter(w -> Boolean.TRUE.equals(w.getActive()))
                 .orElseThrow(() -> new SecurityException("Funding wallet is not owned by the contributor"));
+
         if (wallet.getLightning() == null || wallet.getLightning().get("inkey") == null ||
                 fundingWallet.getLightning() == null || fundingWallet.getLightning().get("adminkey") == null)
             throw new IllegalStateException("Both wallets must have Lightning credentials");
+
         String invoice = lightningWalletService.createInvoice(wallet.getLightning().get("inkey"),
                 request.amountSats(), "Contribution to " + wallet.getChama().getName());
+
+        FeeQuote fee = feeService.quote(TransactionCategory.GROUP_WALLET_TOPUP, request.amountSats());
         String paymentReference = lightningWalletService.payInvoice(
                 fundingWallet.getLightning().get("adminkey"), invoice);
+        String feePaymentReference = feeService.collect(fundingWallet, fee);
+
         wallet.setBalanceSats(Math.addExact(wallet.getBalanceSats(), request.amountSats()));
         walletRepository.save(wallet);
+
         GroupWalletContribution saved = contributionRepository.save(GroupWalletContribution.builder()
                 .chama(wallet.getChama()).wallet(wallet).contributor(user)
-                .amountSats(request.amountSats()).externalReference(paymentReference).build());
+                .amountSats(request.amountSats()).externalReference(paymentReference)
+                .platformFeeSats(fee.platformFeeSats()).feeRuleReference(fee.feeRuleReference())
+                .feePaymentReference(feePaymentReference).build());
+
         long target = wallet.getTargetAmountSats() == null ? 0 : wallet.getTargetAmountSats();
+
         notifications.notifyGroupWalletContribution(user, wallet.getChama(), request.amountSats(),
                 wallet.getBalanceSats(), wallet.getTargetAmountSats());
+
         return new GroupWalletContributionResponse(saved.getReference(), walletId, request.amountSats(),
                 wallet.getBalanceSats(), wallet.getTargetAmountSats(), Math.max(0, target - wallet.getBalanceSats()),
-                paymentReference, saved.getContributedAt());
+                fee.platformFeeSats(), fee.totalSats(), fee.feeRuleReference(), paymentReference,
+                feePaymentReference, saved.getContributedAt());
     }
 }

--- a/chamavault/src/main/java/com/dada_labs_two/chamavault/fees/controllers/FeeController.java
+++ b/chamavault/src/main/java/com/dada_labs_two/chamavault/fees/controllers/FeeController.java
@@ -1,0 +1,41 @@
+package com.dada_labs_two.chamavault.fees.controllers;
+
+import com.dada_labs_two.chamavault.fees.dtos.*;
+import com.dada_labs_two.chamavault.fees.models.FeeRule;
+import com.dada_labs_two.chamavault.fees.services.FeeService;
+import com.dada_labs_two.chamavault.users.models.User;
+import com.dada_labs_two.chamavault.wallets.constants.TransactionCategory;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/fees")
+public class FeeController {
+    private final FeeService service;
+
+    @GetMapping("/quote")
+    public FeeQuote quote(@RequestParam TransactionCategory category, @RequestParam long amountSats) {
+        return service.quote(category, amountSats);
+    }
+
+    @PostMapping("/rules")
+    public ResponseEntity<FeeRule> create(@AuthenticationPrincipal User user, @Valid @RequestBody CreateFeeRuleRequest request) {
+        return ResponseEntity.ok(service.create(request, user));
+    }
+
+    @GetMapping("/rules")
+    public List<FeeRule> list(@AuthenticationPrincipal User user, @RequestParam TransactionCategory category) {
+        return service.list(category, user);
+    }
+
+    @DeleteMapping("/rules/{id}")
+    public FeeRule disable(@AuthenticationPrincipal User user, @PathVariable UUID id) {
+        return service.disable(id, user);
+    }
+}

--- a/chamavault/src/main/java/com/dada_labs_two/chamavault/fees/dtos/CreateFeeRuleRequest.java
+++ b/chamavault/src/main/java/com/dada_labs_two/chamavault/fees/dtos/CreateFeeRuleRequest.java
@@ -1,0 +1,13 @@
+package com.dada_labs_two.chamavault.fees.dtos;
+
+import com.dada_labs_two.chamavault.wallets.constants.TransactionCategory;
+import jakarta.validation.constraints.*;
+
+import java.math.BigDecimal;
+import java.time.ZonedDateTime;
+
+public record CreateFeeRuleRequest(@NotNull TransactionCategory category,
+                                   @NotNull @DecimalMin("0.0") @DecimalMax("100.0") BigDecimal percentage,
+                                   @PositiveOrZero Long minimumFeeSats, @Positive Long maximumFeeSats,
+                                   ZonedDateTime effectiveFrom, ZonedDateTime effectiveUntil) {
+}

--- a/chamavault/src/main/java/com/dada_labs_two/chamavault/fees/dtos/FeeQuote.java
+++ b/chamavault/src/main/java/com/dada_labs_two/chamavault/fees/dtos/FeeQuote.java
@@ -1,0 +1,10 @@
+package com.dada_labs_two.chamavault.fees.dtos;
+
+import com.dada_labs_two.chamavault.wallets.constants.TransactionCategory;
+
+import java.math.BigDecimal;
+import java.util.UUID;
+
+public record FeeQuote(TransactionCategory category, long amountSats, long platformFeeSats, long totalSats,
+                       BigDecimal percentage, UUID feeRuleReference) {
+}

--- a/chamavault/src/main/java/com/dada_labs_two/chamavault/fees/models/FeeRule.java
+++ b/chamavault/src/main/java/com/dada_labs_two/chamavault/fees/models/FeeRule.java
@@ -1,0 +1,46 @@
+package com.dada_labs_two.chamavault.fees.models;
+
+import com.dada_labs_two.chamavault.wallets.constants.TransactionCategory;
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.CreationTimestamp;
+
+import java.math.BigDecimal;
+import java.time.ZonedDateTime;
+import java.util.UUID;
+
+@Entity
+@Table(name = "fee_rules", indexes = @Index(name = "idx_fee_rule_lookup", columnList = "category,active,effective_from"))
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class FeeRule {
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID reference;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private TransactionCategory category;
+
+    @Column(nullable = false, precision = 8, scale = 5)
+    private BigDecimal percentage;
+
+    private Long minimumFeeSats;
+    private Long maximumFeeSats;
+
+    @Column(name = "effective_from", nullable = false)
+    private ZonedDateTime effectiveFrom;
+    private ZonedDateTime effectiveUntil;
+
+    @Column(nullable = false)
+    private Boolean active;
+
+    @Column(nullable = false)
+    private UUID createdBy;
+
+    @CreationTimestamp
+    private ZonedDateTime createdAt;
+}

--- a/chamavault/src/main/java/com/dada_labs_two/chamavault/fees/repositories/FeeRuleRepository.java
+++ b/chamavault/src/main/java/com/dada_labs_two/chamavault/fees/repositories/FeeRuleRepository.java
@@ -1,0 +1,16 @@
+package com.dada_labs_two.chamavault.fees.repositories;
+
+import com.dada_labs_two.chamavault.fees.models.FeeRule;
+import com.dada_labs_two.chamavault.wallets.constants.TransactionCategory;
+import org.springframework.data.jpa.repository.*;
+import org.springframework.data.repository.query.Param;
+
+import java.time.ZonedDateTime;
+import java.util.*;
+
+public interface FeeRuleRepository extends JpaRepository<FeeRule, UUID> {
+    @Query("select f from FeeRule f where f.category=:category and f.active=true and f.effectiveFrom<=:at and (f.effectiveUntil is null or f.effectiveUntil>:at) order by f.effectiveFrom desc")
+    List<FeeRule> findEffective(@Param("category") TransactionCategory category, @Param("at") ZonedDateTime at);
+
+    List<FeeRule> findByCategoryOrderByEffectiveFromDesc(TransactionCategory category);
+}

--- a/chamavault/src/main/java/com/dada_labs_two/chamavault/fees/services/FeeService.java
+++ b/chamavault/src/main/java/com/dada_labs_two/chamavault/fees/services/FeeService.java
@@ -1,0 +1,118 @@
+package com.dada_labs_two.chamavault.fees.services;
+
+import com.dada_labs_two.chamavault.fees.dtos.*;
+import com.dada_labs_two.chamavault.fees.models.FeeRule;
+import com.dada_labs_two.chamavault.fees.repositories.FeeRuleRepository;
+import com.dada_labs_two.chamavault.lightning.services.LightningWalletService;
+import com.dada_labs_two.chamavault.users.models.User;
+import com.dada_labs_two.chamavault.wallets.constants.TransactionCategory;
+import com.dada_labs_two.chamavault.wallets.models.Wallet;
+import com.dada_labs_two.chamavault.wallets.repositories.WalletRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.math.*;
+import java.time.ZonedDateTime;
+import java.util.*;
+
+@Service
+@RequiredArgsConstructor
+public class FeeService {
+    private final FeeRuleRepository repository;
+    private final WalletRepository walletRepository;
+    private final LightningWalletService lightningWalletService;
+
+    @Value("${fees.collection-wallet-id:}")
+    private String collectionWalletId;
+
+    public FeeQuote quote(TransactionCategory category, long amountSats) {
+        if (amountSats <= 0) throw new IllegalArgumentException("amountSats must be positive");
+
+        List<FeeRule> rules = repository.findEffective(category, ZonedDateTime.now());
+
+        if (rules.size() > 1) throw new IllegalStateException("Overlapping active fee rules for " + category);
+
+        if (rules.isEmpty()) return new FeeQuote(category, amountSats, 0, amountSats, BigDecimal.ZERO, null);
+
+        FeeRule rule = rules.getFirst();
+        long fee = new BigDecimal(amountSats).multiply(rule.getPercentage())
+                .divide(new BigDecimal("100"), 0, RoundingMode.CEILING).longValueExact();
+
+        if (rule.getMinimumFeeSats() != null) fee = Math.max(fee, rule.getMinimumFeeSats());
+        if (rule.getMaximumFeeSats() != null) fee = Math.min(fee, rule.getMaximumFeeSats());
+
+        return new FeeQuote(category, amountSats, fee, Math.addExact(amountSats, fee), rule.getPercentage(), rule.getReference());
+    }
+
+    public String collect(Wallet payer, FeeQuote quote) {
+        if (quote.platformFeeSats() == 0) return null;
+
+        if (collectionWalletId == null || collectionWalletId.isBlank())
+            throw new IllegalStateException("fees.collection-wallet-id is required when a non-zero fee is active");
+
+        Wallet collector = walletRepository.findById(UUID.fromString(collectionWalletId)).orElseThrow(
+                () -> new IllegalStateException("Fee collection wallet not found"));
+
+        if (payer.getLightning() == null || payer.getLightning().get("adminkey") == null)
+            throw new IllegalStateException("Payer wallet has no Lightning admin key");
+
+        if (collector.getLightning() == null || collector.getLightning().get("inkey") == null)
+            throw new IllegalStateException("Fee collection wallet has no Lightning invoice key");
+
+        String invoice = lightningWalletService.createInvoice(collector.getLightning().get("inkey"), quote.platformFeeSats(), "ChamaVault " + quote.category() + " fee");
+        return lightningWalletService.payInvoice(payer.getLightning().get("adminkey"), invoice);
+    }
+
+    @Transactional
+    public FeeRule create(CreateFeeRuleRequest input, User user) {
+        assertAdmin(user);
+
+        ZonedDateTime from = input.effectiveFrom() == null ? ZonedDateTime.now() : input.effectiveFrom();
+
+        if (input.effectiveUntil() != null && !input.effectiveUntil().isAfter(from))
+            throw new IllegalArgumentException("effectiveUntil must be after effectiveFrom");
+
+        if (input.minimumFeeSats() != null && input.maximumFeeSats() != null && input.minimumFeeSats() > input.maximumFeeSats())
+            throw new IllegalArgumentException("minimumFeeSats cannot exceed maximumFeeSats");
+
+        for (FeeRule existing : repository.findByCategoryOrderByEffectiveFromDesc(input.category())) {
+            if (!Boolean.TRUE.equals(existing.getActive())) continue;
+            boolean overlaps = (existing.getEffectiveUntil() == null || existing.getEffectiveUntil().isAfter(from)) &&
+                    (input.effectiveUntil() == null || existing.getEffectiveFrom().isBefore(input.effectiveUntil()));
+            if (!overlaps) continue;
+            if (existing.getEffectiveFrom().isBefore(from) && (existing.getEffectiveUntil() == null || existing.getEffectiveUntil().isAfter(from))) {
+                existing.setEffectiveUntil(from);
+                repository.save(existing);
+            } else throw new IllegalArgumentException("Fee rule overlaps another scheduled rule");
+        }
+        return repository.save(FeeRule.builder().category(input.category()).percentage(input.percentage())
+                .minimumFeeSats(input.minimumFeeSats()).maximumFeeSats(input.maximumFeeSats()).effectiveFrom(from)
+                .effectiveUntil(input.effectiveUntil()).active(true).createdBy(user.getUserReference()).build());
+    }
+
+    public List<FeeRule> list(TransactionCategory category, User user) {
+        assertAdmin(user);
+        return repository.findByCategoryOrderByEffectiveFromDesc(category);
+    }
+
+    @Transactional
+    public FeeRule disable(UUID id, User user) {
+        assertAdmin(user);
+        FeeRule rule = repository.findById(id).orElseThrow();
+        rule.setActive(false);
+        return repository.save(rule);
+    }
+
+    private void assertAdmin(User user) {
+        if (user == null)
+            throw new SecurityException("Authentication required");
+
+        boolean admin = user.getAuthorities() != null && user.getAuthorities().stream().anyMatch(
+                a -> a.getAuthority().equalsIgnoreCase("ADMIN") ||
+                        a.getAuthority().equalsIgnoreCase("ROLE_ADMIN"));
+
+        if (!admin) throw new SecurityException("Platform administrator role required");
+    }
+}

--- a/chamavault/src/main/java/com/dada_labs_two/chamavault/governance/constants/CheckerDecision.java
+++ b/chamavault/src/main/java/com/dada_labs_two/chamavault/governance/constants/CheckerDecision.java
@@ -1,0 +1,3 @@
+package com.dada_labs_two.chamavault.governance.constants;
+
+public enum CheckerDecision { APPROVE, DISAPPROVE }

--- a/chamavault/src/main/java/com/dada_labs_two/chamavault/governance/constants/GovernanceAction.java
+++ b/chamavault/src/main/java/com/dada_labs_two/chamavault/governance/constants/GovernanceAction.java
@@ -1,0 +1,13 @@
+package com.dada_labs_two.chamavault.governance.constants;
+
+public enum GovernanceAction {
+    WITHDRAW_GROUP_WALLET,
+    CREATE_GROUP_WALLET,
+    REMOVE_MEMBER,
+    ISSUE_FINE,
+    SUSPEND_MEMBER,
+    CHANGE_CONTRIBUTION_AMOUNT,
+    CHANGE_MAX_MEMBERS,
+    SKIP_ROTATION_MEMBER,
+    CHANGE_CHAMA_CONFIG
+}

--- a/chamavault/src/main/java/com/dada_labs_two/chamavault/governance/constants/GovernanceRequestStatus.java
+++ b/chamavault/src/main/java/com/dada_labs_two/chamavault/governance/constants/GovernanceRequestStatus.java
@@ -1,0 +1,3 @@
+package com.dada_labs_two.chamavault.governance.constants;
+
+public enum GovernanceRequestStatus { PENDING, APPROVED, REJECTED, EXECUTED }

--- a/chamavault/src/main/java/com/dada_labs_two/chamavault/governance/controllers/GovernanceController.java
+++ b/chamavault/src/main/java/com/dada_labs_two/chamavault/governance/controllers/GovernanceController.java
@@ -1,0 +1,44 @@
+package com.dada_labs_two.chamavault.governance.controllers;
+
+import com.dada_labs_two.chamavault.governance.models.GovernanceRequest;
+import com.dada_labs_two.chamavault.governance.services.GovernanceService;
+import com.dada_labs_two.chamavault.governance.dtos.CastVoteRequest;
+import com.dada_labs_two.chamavault.governance.dtos.CreateGovernanceRequest;
+import com.dada_labs_two.chamavault.users.models.User;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.*;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+import java.util.UUID;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/chamas/{chamaId}/governance")
+public class GovernanceController {
+ private final GovernanceService governanceService;
+
+ @PostMapping("/requests")
+ public ResponseEntity<GovernanceRequest> create(@PathVariable UUID chamaId,
+                                                 @AuthenticationPrincipal User user,
+                                                 @Valid @RequestBody CreateGovernanceRequest request){
+  return ResponseEntity.ok(
+          governanceService.create(chamaId,user,request)
+  ); }
+
+ @GetMapping("/requests")
+ public ResponseEntity<Page<GovernanceRequest>> list(@PathVariable UUID chamaId,
+                                                     @AuthenticationPrincipal User user,
+                                                     Pageable pageable) {
+  return ResponseEntity.ok(governanceService.list(chamaId,user,pageable));
+ }
+ @PostMapping("/requests/{requestId}/votes")
+ public ResponseEntity<GovernanceRequest> vote(@PathVariable UUID chamaId,
+                                               @PathVariable UUID requestId,
+                                               @AuthenticationPrincipal User user,
+                                               @Valid @RequestBody CastVoteRequest vote) {
+   return ResponseEntity.ok(governanceService.vote(chamaId,requestId,user,vote));
+ }
+
+}

--- a/chamavault/src/main/java/com/dada_labs_two/chamavault/governance/dtos/CastVoteRequest.java
+++ b/chamavault/src/main/java/com/dada_labs_two/chamavault/governance/dtos/CastVoteRequest.java
@@ -1,0 +1,5 @@
+package com.dada_labs_two.chamavault.governance.dtos;
+import com.dada_labs_two.chamavault.governance.constants.CheckerDecision;
+import jakarta.validation.constraints.NotNull;
+
+public record CastVoteRequest(@NotNull CheckerDecision decision, String comment) {}

--- a/chamavault/src/main/java/com/dada_labs_two/chamavault/governance/dtos/CreateGovernanceRequest.java
+++ b/chamavault/src/main/java/com/dada_labs_two/chamavault/governance/dtos/CreateGovernanceRequest.java
@@ -1,0 +1,9 @@
+package com.dada_labs_two.chamavault.governance.dtos;
+import com.dada_labs_two.chamavault.governance.constants.GovernanceAction;
+import jakarta.validation.constraints.NotNull;
+import java.util.Map;
+public record CreateGovernanceRequest(
+        @NotNull GovernanceAction action,
+        @NotNull Map<String,String> parameters,
+        String reason
+) {}

--- a/chamavault/src/main/java/com/dada_labs_two/chamavault/governance/models/ChamaFine.java
+++ b/chamavault/src/main/java/com/dada_labs_two/chamavault/governance/models/ChamaFine.java
@@ -1,0 +1,37 @@
+package com.dada_labs_two.chamavault.governance.models;
+import com.dada_labs_two.chamavault.chama.models.*;
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.CreationTimestamp;
+import java.time.ZonedDateTime;
+import java.util.UUID;
+
+@Entity
+@Table(name="chama_fines")
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ChamaFine {
+ @Id
+ @GeneratedValue(strategy=GenerationType.UUID)
+ private UUID reference;
+
+ @ManyToOne(optional=false)
+ private Chama chama;
+
+ @ManyToOne(optional=false)
+ private ChamaMember member;
+
+ @Column(nullable=false)
+ private Long amountSats;
+
+ private String reason;
+
+ @Column(nullable=false)
+ private Boolean paid;
+
+ @CreationTimestamp
+ private ZonedDateTime createdAt;
+}

--- a/chamavault/src/main/java/com/dada_labs_two/chamavault/governance/models/GovernanceRequest.java
+++ b/chamavault/src/main/java/com/dada_labs_two/chamavault/governance/models/GovernanceRequest.java
@@ -1,0 +1,59 @@
+package com.dada_labs_two.chamavault.governance.models;
+
+import com.dada_labs_two.chamavault.chama.models.*;
+import com.dada_labs_two.chamavault.governance.constants.GovernanceRequestStatus;
+import com.dada_labs_two.chamavault.governance.constants.GovernanceAction;
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.annotations.UpdateTimestamp;
+import org.hibernate.type.SqlTypes;
+import java.time.ZonedDateTime;
+import java.util.*;
+
+@Entity
+@Table(name = "chama_governance_requests")
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class GovernanceRequest {
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID reference;
+
+    @ManyToOne(optional = false)
+    @JoinColumn(name = "chama_reference")
+    private Chama chama;
+
+    @ManyToOne(optional = false)
+    @JoinColumn(name = "maker_member_reference")
+    private ChamaMember maker;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private GovernanceAction action;
+
+    @JdbcTypeCode(SqlTypes.JSON)
+    @Column(nullable = false)
+    private Map<String, String> parameters;
+
+    private String reason;
+
+    @Column(nullable = false)
+    private Integer requiredApprovals;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private GovernanceRequestStatus status;
+
+    @CreationTimestamp
+    private ZonedDateTime createdAt;
+
+    @UpdateTimestamp
+    private ZonedDateTime updatedAt;
+
+    private ZonedDateTime decidedAt;
+}

--- a/chamavault/src/main/java/com/dada_labs_two/chamavault/governance/models/GovernanceVote.java
+++ b/chamavault/src/main/java/com/dada_labs_two/chamavault/governance/models/GovernanceVote.java
@@ -1,0 +1,40 @@
+package com.dada_labs_two.chamavault.governance.models;
+
+import com.dada_labs_two.chamavault.chama.models.ChamaMember;
+import com.dada_labs_two.chamavault.governance.constants.CheckerDecision;
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.CreationTimestamp;
+import java.time.ZonedDateTime;
+import java.util.UUID;
+
+@Entity
+@Table(name = "chama_governance_votes", uniqueConstraints =
+        @UniqueConstraint(name = "uk_governance_request_checker", columnNames = {"request_reference", "checker_member_reference"}))
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class GovernanceVote {
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID reference;
+
+    @ManyToOne(optional = false)
+    @JoinColumn(name = "request_reference")
+    private GovernanceRequest request;
+
+    @ManyToOne(optional = false)
+    @JoinColumn(name = "checker_member_reference")
+    private ChamaMember checker;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private CheckerDecision decision;
+
+    private String comment;
+
+    @CreationTimestamp
+    private ZonedDateTime createdAt;
+}

--- a/chamavault/src/main/java/com/dada_labs_two/chamavault/governance/repositories/ChamaFineRepository.java
+++ b/chamavault/src/main/java/com/dada_labs_two/chamavault/governance/repositories/ChamaFineRepository.java
@@ -1,0 +1,6 @@
+package com.dada_labs_two.chamavault.governance.repositories;
+import com.dada_labs_two.chamavault.governance.models.ChamaFine;
+import org.springframework.data.jpa.repository.JpaRepository;
+import java.util.UUID;
+
+public interface ChamaFineRepository extends JpaRepository<ChamaFine, UUID> {}

--- a/chamavault/src/main/java/com/dada_labs_two/chamavault/governance/repositories/GovernanceRequestRepository.java
+++ b/chamavault/src/main/java/com/dada_labs_two/chamavault/governance/repositories/GovernanceRequestRepository.java
@@ -1,0 +1,8 @@
+package com.dada_labs_two.chamavault.governance.repositories;
+import com.dada_labs_two.chamavault.governance.models.GovernanceRequest;
+import org.springframework.data.domain.*;
+import org.springframework.data.jpa.repository.JpaRepository;
+import java.util.UUID;
+public interface GovernanceRequestRepository extends JpaRepository<GovernanceRequest, UUID> {
+ Page<GovernanceRequest> findByChama_ChamaReference(UUID chamaReference, Pageable pageable);
+}

--- a/chamavault/src/main/java/com/dada_labs_two/chamavault/governance/repositories/GovernanceVoteRepository.java
+++ b/chamavault/src/main/java/com/dada_labs_two/chamavault/governance/repositories/GovernanceVoteRepository.java
@@ -1,0 +1,11 @@
+package com.dada_labs_two.chamavault.governance.repositories;
+import com.dada_labs_two.chamavault.governance.constants.CheckerDecision;
+import com.dada_labs_two.chamavault.governance.models.GovernanceRequest;
+import com.dada_labs_two.chamavault.governance.models.GovernanceVote;
+import org.springframework.data.jpa.repository.JpaRepository;
+import java.util.*;
+
+public interface GovernanceVoteRepository extends JpaRepository<GovernanceVote, UUID> {
+ boolean existsByRequestAndChecker(GovernanceRequest request, com.dada_labs_two.chamavault.chama.models.ChamaMember checker);
+ long countByRequestAndDecision(GovernanceRequest request, CheckerDecision decision);
+}

--- a/chamavault/src/main/java/com/dada_labs_two/chamavault/governance/services/GovernanceService.java
+++ b/chamavault/src/main/java/com/dada_labs_two/chamavault/governance/services/GovernanceService.java
@@ -22,14 +22,23 @@ import com.dada_labs_two.chamavault.wallets.constants.WalletType;
 import com.dada_labs_two.chamavault.wallets.models.Wallet;
 import com.dada_labs_two.chamavault.wallets.repositories.WalletRepository;
 import com.dada_labs_two.chamavault.wallets.services.Bolt11Utils;
+import com.dada_labs_two.chamavault.fees.services.FeeService;
+import com.dada_labs_two.chamavault.fees.dtos.FeeQuote;
+import com.dada_labs_two.chamavault.wallets.constants.TransactionCategory;
+import com.dada_labs_two.chamavault.wallets.constants.TransactionSource;
+import com.dada_labs_two.chamavault.wallets.constants.TransactionType;
+import com.dada_labs_two.chamavault.wallets.models.Transaction;
+import com.dada_labs_two.chamavault.wallets.repositories.TransactionRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.*;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
 import java.time.ZonedDateTime;
 import java.util.*;
 
-@Service @RequiredArgsConstructor
+@Service
+@RequiredArgsConstructor
 public class GovernanceService {
     private final GovernanceRequestRepository requestRepository;
     private final GovernanceVoteRepository voteRepository;
@@ -40,6 +49,8 @@ public class GovernanceService {
     private final WalletRepository walletRepository;
     private final ProfileActionService notifications;
     private final LightningWalletService lightningWalletService;
+    private final FeeService feeService;
+    private final TransactionRepository transactionRepository;
 
     @Transactional
     public GovernanceRequest create(UUID chamaId, User user, CreateGovernanceRequest input) {
@@ -91,7 +102,7 @@ public class GovernanceService {
                         .checker(checker)
                         .decision(input.decision())
                         .comment(input.comment())
-                .build());
+                        .build());
 
         long votes = voteRepository.countByRequestAndDecision(request, input.decision());
 
@@ -110,16 +121,19 @@ public class GovernanceService {
     }
 
     private void execute(GovernanceRequest r) {
-        Map<String,String> p = r.getParameters();
+        Map<String, String> p = r.getParameters();
         Chama chama = r.getChama();
         ChamaRules rules = rulesRepository.findByChama(chama).orElseThrow();
         switch (r.getAction()) {
             case CREATE_GROUP_WALLET -> {
                 WalletResponse lw = lightningWalletService.createUserWallet(chama.getName() + " group wallet");
-                Map<String,String> lightning = new HashMap<>();
-                lightning.put("id", lw.id()); lightning.put("walletName", lw.name());
-                lightning.put("adminkey", lw.adminkey()); lightning.put("inkey", lw.inkey());
-                lightning.put("invoice_key", lw.invoice_key()); lightning.put("currency", lw.currency());
+                Map<String, String> lightning = new HashMap<>();
+                lightning.put("id", lw.id());
+                lightning.put("walletName", lw.name());
+                lightning.put("adminkey", lw.adminkey());
+                lightning.put("inkey", lw.inkey());
+                lightning.put("invoice_key", lw.invoice_key());
+                lightning.put("currency", lw.currency());
                 walletRepository.save(Wallet.builder().walletType(WalletType.CHAMA_GROUP)
                         .ownerReference(chama.getChamaReference()).chama(chama).balanceSats(0L).lightning(lightning)
                         .targetAmountSats(longParam(p, "targetAmountSats")).walletPurpose(p.getOrDefault("purpose", "Chama group wallet"))
@@ -128,7 +142,9 @@ public class GovernanceService {
             case WITHDRAW_GROUP_WALLET -> {
                 Wallet wallet = groupWallet(chama, p);
                 long amount = longParam(p, "amountSats");
-                if (wallet.getBalanceSats() < amount) throw new IllegalStateException("Insufficient group wallet balance");
+                FeeQuote fee = feeService.quote(TransactionCategory.WITHDRAWAL, amount);
+                if (wallet.getBalanceSats() < fee.totalSats())
+                    throw new IllegalStateException("Insufficient group wallet balance including fee");
                 if (wallet.getLightning() == null || wallet.getLightning().get("adminkey") == null)
                     throw new IllegalStateException("Group wallet has no Lightning credentials");
                 String destination = required(p, "destination");
@@ -136,66 +152,119 @@ public class GovernanceService {
                     throw new IllegalArgumentException("Invoice amount must equal amountSats");
                 if (Bolt11Utils.extractExpiry(destination).isBefore(ZonedDateTime.now()))
                     throw new IllegalArgumentException("Destination invoice is expired");
-                lightningWalletService.payInvoice(wallet.getLightning().get("adminkey"), destination);
-                wallet.setBalanceSats(wallet.getBalanceSats() - amount);
+                String paymentHash = lightningWalletService.payInvoice(wallet.getLightning().get("adminkey"), destination);
+                String feePaymentHash = feeService.collect(wallet, fee);
+                wallet.setBalanceSats(wallet.getBalanceSats() - fee.totalSats());
                 walletRepository.save(wallet);
+                Map<String, String> metadata = new HashMap<>();
+                metadata.put("governanceRequest", r.getReference().toString());
+                metadata.put("destinationInvoiceHash", Bolt11Utils.extractPaymentHash(destination));
+                metadata.put("platformFeeSats", String.valueOf(fee.platformFeeSats()));
+                if (feePaymentHash != null) metadata.put("feePaymentHash", feePaymentHash);
+                transactionRepository.save(Transaction.builder().wallet(wallet).type(TransactionType.DEBIT)
+                        .source(TransactionSource.LN_INVOICE).category(TransactionCategory.WITHDRAWAL)
+                        .amountSats(amount).platformFeeSats(fee.platformFeeSats()).feeSats(fee.platformFeeSats())
+                        .feeRuleReference(fee.feeRuleReference()).externalRef(paymentHash)
+                        .initiatedBy(r.getMaker().getUser().getUserReference()).memo(r.getReason())
+                        .metadata(metadata).occurredAt(ZonedDateTime.now()).build());
             }
-            case REMOVE_MEMBER -> { ChamaMember m = member(chama, p); m.setStatus(MembershipStatus.REMOVED); memberRepository.save(m); }
-            case SUSPEND_MEMBER -> { ChamaMember m = member(chama, p); m.setStatus(MembershipStatus.SUSPENDED); memberRepository.save(m); }
-            case ISSUE_FINE -> fineRepository.save(ChamaFine.builder().chama(chama).member(member(chama,p))
-                    .amountSats(longParam(p,"amountSats")).reason(p.get("reason")).paid(false).build());
-            case CHANGE_CONTRIBUTION_AMOUNT -> { long v=longParam(p,"contributionAmount"); rules.setContributionAmount(v); chama.setContributionAmount(v); rulesRepository.save(rules); chamaRepository.save(chama); }
-            case CHANGE_MAX_MEMBERS -> { int v=Math.toIntExact(longParam(p,"maxMembers")); if(v < memberRepository.countByChama_ChamaReferenceAndStatus(chama.getChamaReference(), MembershipStatus.ACTIVE)) throw new IllegalArgumentException("maxMembers is below active member count"); chama.setMaxMembers(v); chamaRepository.save(chama); }
-            case SKIP_ROTATION_MEMBER -> { chama.setCurrentRotationIndex(chama.getCurrentRotationIndex()+1); chamaRepository.save(chama); }
+            case REMOVE_MEMBER -> {
+                ChamaMember m = member(chama, p);
+                m.setStatus(MembershipStatus.REMOVED);
+                memberRepository.save(m);
+            }
+            case SUSPEND_MEMBER -> {
+                ChamaMember m = member(chama, p);
+                m.setStatus(MembershipStatus.SUSPENDED);
+                memberRepository.save(m);
+            }
+            case ISSUE_FINE -> fineRepository.save(ChamaFine.builder().chama(chama).member(member(chama, p))
+                    .amountSats(longParam(p, "amountSats")).reason(p.get("reason")).paid(false).build());
+            case CHANGE_CONTRIBUTION_AMOUNT -> {
+                long v = longParam(p, "contributionAmount");
+                rules.setContributionAmount(v);
+                chama.setContributionAmount(v);
+                rulesRepository.save(rules);
+                chamaRepository.save(chama);
+            }
+            case CHANGE_MAX_MEMBERS -> {
+                int v = Math.toIntExact(longParam(p, "maxMembers"));
+                if (v < memberRepository.countByChama_ChamaReferenceAndStatus(chama.getChamaReference(), MembershipStatus.ACTIVE))
+                    throw new IllegalArgumentException("maxMembers is below active member count");
+                chama.setMaxMembers(v);
+                chamaRepository.save(chama);
+            }
+            case SKIP_ROTATION_MEMBER -> {
+                chama.setCurrentRotationIndex(chama.getCurrentRotationIndex() + 1);
+                chamaRepository.save(chama);
+            }
             case CHANGE_CHAMA_CONFIG -> applyConfig(chama, rules, p);
         }
         r.setStatus(GovernanceRequestStatus.EXECUTED);
     }
 
-    private void applyConfig(Chama c, ChamaRules rules, Map<String,String> p) {
+    private void applyConfig(Chama c, ChamaRules rules, Map<String, String> p) {
         if (p.containsKey("description")) c.setDescription(p.get("description"));
-        if (p.containsKey("requiredApprovals")) rules.setRequiredApprovals(Math.toIntExact(longParam(p,"requiredApprovals")));
-        if (p.containsKey("dailyLimitSats")) rules.setDailyLimitSats(longParam(p,"dailyLimitSats"));
-        chamaRepository.save(c); rulesRepository.save(rules);
+        if (p.containsKey("requiredApprovals"))
+            rules.setRequiredApprovals(Math.toIntExact(longParam(p, "requiredApprovals")));
+        if (p.containsKey("dailyLimitSats")) rules.setDailyLimitSats(longParam(p, "dailyLimitSats"));
+        chamaRepository.save(c);
+        rulesRepository.save(rules);
     }
+
     private ChamaMember activeMember(UUID chamaId, User u) {
         return memberRepository
-            .findByChama_ChamaReferenceAndUser_UserReferenceAndStatus(chamaId,u.getUserReference(),MembershipStatus.ACTIVE)
-            .orElseThrow(() -> new SecurityException("Only active chama members may use governance"));
+                .findByChama_ChamaReferenceAndUser_UserReferenceAndStatus(chamaId, u.getUserReference(), MembershipStatus.ACTIVE)
+                .orElseThrow(() -> new SecurityException("Only active chama members may use governance"));
     }
 
-    private ChamaMember member(Chama c, Map<String,String> p) { UUID id=UUID.fromString(required(p,"memberReference")); ChamaMember m=memberRepository.findById(id).orElseThrow(); if(!m.getChama().getChamaReference().equals(c.getChamaReference())) throw new IllegalArgumentException("Member is not in chama"); return m; }
-    private Wallet groupWallet(Chama c, Map<String,String> p) { return walletRepository.findByWalletReferenceAndChama_ChamaReferenceAndWalletTypeAndActiveTrue(UUID.fromString(required(p,"walletReference")),c.getChamaReference(),WalletType.CHAMA_GROUP).orElseThrow(); }
+    private ChamaMember member(Chama c, Map<String, String> p) {
+        UUID id = UUID.fromString(required(p, "memberReference"));
+        ChamaMember m = memberRepository.findById(id).orElseThrow();
+        if (!m.getChama().getChamaReference().equals(c.getChamaReference()))
+            throw new IllegalArgumentException("Member is not in chama");
+        return m;
+    }
 
-    private long longParam(Map<String,String> p,String key) {
-        long value=Long.parseLong(required(p,key));
-        if(value<=0) throw new IllegalArgumentException(key+" must be positive");
+    private Wallet groupWallet(Chama c, Map<String, String> p) {
+        return walletRepository.findByWalletReferenceAndChama_ChamaReferenceAndWalletTypeAndActiveTrue(UUID.fromString(required(p, "walletReference")), c.getChamaReference(), WalletType.CHAMA_GROUP).orElseThrow();
+    }
+
+    private long longParam(Map<String, String> p, String key) {
+        long value = Long.parseLong(required(p, key));
+        if (value <= 0) throw new IllegalArgumentException(key + " must be positive");
         return value;
     }
 
-    private String required(Map<String,String> p,String key) { String value=p.get(key); if(value==null||value.isBlank()) throw new IllegalArgumentException(key+" is required"); return value; }
+    private String required(Map<String, String> p, String key) {
+        String value = p.get(key);
+        if (value == null || value.isBlank()) throw new IllegalArgumentException(key + " is required");
+        return value;
+    }
 
-    private void validateParameters(GovernanceAction a, Map<String,String> p) {
-        switch(a) {
-            case CREATE_GROUP_WALLET -> longParam(p,"targetAmountSats");
+    private void validateParameters(GovernanceAction a, Map<String, String> p) {
+        switch (a) {
+            case CREATE_GROUP_WALLET -> longParam(p, "targetAmountSats");
             case WITHDRAW_GROUP_WALLET -> {
-                required(p,"walletReference");
-                longParam(p,"amountSats");
-                required(p,"destination");
+                required(p, "walletReference");
+                longParam(p, "amountSats");
+                required(p, "destination");
             }
-            case REMOVE_MEMBER, SUSPEND_MEMBER -> required(p,"memberReference");
+            case REMOVE_MEMBER, SUSPEND_MEMBER -> required(p, "memberReference");
             case ISSUE_FINE -> {
-                required(p,"memberReference");
-                longParam(p,"amountSats");
+                required(p, "memberReference");
+                longParam(p, "amountSats");
             }
-            case CHANGE_CONTRIBUTION_AMOUNT -> longParam(p,"contributionAmount");
-            case CHANGE_MAX_MEMBERS -> longParam(p,"maxMembers");
-            case SKIP_ROTATION_MEMBER -> required(p,"memberReference");
+            case CHANGE_CONTRIBUTION_AMOUNT -> longParam(p, "contributionAmount");
+            case CHANGE_MAX_MEMBERS -> longParam(p, "maxMembers");
+            case SKIP_ROTATION_MEMBER -> required(p, "memberReference");
             case CHANGE_CHAMA_CONFIG -> {
-                if(p.isEmpty()) throw new IllegalArgumentException("At least one config field is required");
+                if (p.isEmpty()) throw new IllegalArgumentException("At least one config field is required");
             }
         }
     }
 
-    private void notifyMembers(GovernanceRequest r,String subject,User actor) { memberRepository.findMembersByChamaAndStatus(r.getChama().getChamaReference(),MembershipStatus.ACTIVE).forEach(m -> notifications.notifyGovernance(m.getUser(),r.getChama(),subject,r.getAction().name(),actor.getUsername())); }
+    private void notifyMembers(GovernanceRequest r, String subject, User actor) {
+        memberRepository.findMembersByChamaAndStatus(r.getChama().getChamaReference(), MembershipStatus.ACTIVE).forEach(m -> notifications.notifyGovernance(m.getUser(), r.getChama(), subject, r.getAction().name(), actor.getUsername()));
+    }
 }

--- a/chamavault/src/main/java/com/dada_labs_two/chamavault/governance/services/GovernanceService.java
+++ b/chamavault/src/main/java/com/dada_labs_two/chamavault/governance/services/GovernanceService.java
@@ -1,0 +1,201 @@
+package com.dada_labs_two.chamavault.governance.services;
+
+import com.dada_labs_two.chamavault.chama.constants.MembershipStatus;
+import com.dada_labs_two.chamavault.chama.models.*;
+import com.dada_labs_two.chamavault.chama.repositories.*;
+import com.dada_labs_two.chamavault.governance.constants.CheckerDecision;
+import com.dada_labs_two.chamavault.governance.constants.GovernanceAction;
+import com.dada_labs_two.chamavault.governance.constants.GovernanceRequestStatus;
+import com.dada_labs_two.chamavault.governance.dtos.CastVoteRequest;
+import com.dada_labs_two.chamavault.governance.dtos.CreateGovernanceRequest;
+import com.dada_labs_two.chamavault.governance.models.ChamaFine;
+import com.dada_labs_two.chamavault.governance.models.GovernanceRequest;
+import com.dada_labs_two.chamavault.governance.models.GovernanceVote;
+import com.dada_labs_two.chamavault.governance.repositories.ChamaFineRepository;
+import com.dada_labs_two.chamavault.governance.repositories.GovernanceRequestRepository;
+import com.dada_labs_two.chamavault.governance.repositories.GovernanceVoteRepository;
+import com.dada_labs_two.chamavault.users.models.User;
+import com.dada_labs_two.chamavault.lightning.integration.LNbits.dtos.WalletResponse;
+import com.dada_labs_two.chamavault.lightning.services.LightningWalletService;
+import com.dada_labs_two.chamavault.users.services.ProfileActionService;
+import com.dada_labs_two.chamavault.wallets.constants.WalletType;
+import com.dada_labs_two.chamavault.wallets.models.Wallet;
+import com.dada_labs_two.chamavault.wallets.repositories.WalletRepository;
+import com.dada_labs_two.chamavault.wallets.services.Bolt11Utils;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.*;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import java.time.ZonedDateTime;
+import java.util.*;
+
+@Service @RequiredArgsConstructor
+public class GovernanceService {
+    private final GovernanceRequestRepository requestRepository;
+    private final GovernanceVoteRepository voteRepository;
+    private final ChamaFineRepository fineRepository;
+    private final ChamaRepository chamaRepository;
+    private final ChamaRulesRepository rulesRepository;
+    private final ChamaMemberRepository memberRepository;
+    private final WalletRepository walletRepository;
+    private final ProfileActionService notifications;
+    private final LightningWalletService lightningWalletService;
+
+    @Transactional
+    public GovernanceRequest create(UUID chamaId, User user, CreateGovernanceRequest input) {
+        ChamaMember maker = activeMember(chamaId, user);
+        ChamaRules rules = rulesRepository.findByChama(maker.getChama()).orElseThrow();
+        int approvals = rules.getRequiredApprovals() == null ? 2 : rules.getRequiredApprovals();
+        long eligibleCheckers = memberRepository.countByChama_ChamaReferenceAndStatus(chamaId, MembershipStatus.ACTIVE) - 1;
+        if (approvals < 1 || approvals > eligibleCheckers)
+            throw new IllegalStateException("Not enough eligible checkers for " + approvals + " approvals");
+        validateParameters(input.action(), input.parameters());
+        GovernanceRequest saved = requestRepository.save(
+                GovernanceRequest.builder()
+                        .chama(maker.getChama())
+                        .maker(maker).action(input.action())
+                        .parameters(input.parameters())
+                        .reason(input.reason())
+                        .requiredApprovals(approvals).status(GovernanceRequestStatus.PENDING)
+                        .build()
+        );
+        notifyMembers(saved, "New maker request", user);
+        return saved;
+    }
+
+    public Page<GovernanceRequest> list(UUID chamaId, User user, Pageable pageable) {
+        activeMember(chamaId, user);
+        return requestRepository.findByChama_ChamaReference(chamaId, pageable);
+    }
+
+    @Transactional
+    public GovernanceRequest vote(UUID chamaId, UUID requestId, User user, CastVoteRequest input) {
+        ChamaMember checker = activeMember(chamaId, user);
+        GovernanceRequest request = requestRepository.findById(requestId).orElseThrow();
+
+        if (!request.getChama().getChamaReference().equals(chamaId))
+            throw new IllegalArgumentException("Request is not for this chama");
+
+        if (request.getStatus() != GovernanceRequestStatus.PENDING)
+            throw new IllegalStateException("Request is already decided");
+
+        if (request.getMaker().getReference().equals(checker.getReference()))
+            throw new IllegalStateException("Maker cannot check their own request");
+
+        if (voteRepository.existsByRequestAndChecker(request, checker))
+            throw new IllegalStateException("Member has already voted");
+
+        voteRepository.save(
+                GovernanceVote.builder()
+                        .request(request)
+                        .checker(checker)
+                        .decision(input.decision())
+                        .comment(input.comment())
+                .build());
+
+        long votes = voteRepository.countByRequestAndDecision(request, input.decision());
+
+        if (votes >= request.getRequiredApprovals()) {
+            request.setDecidedAt(ZonedDateTime.now());
+            if (input.decision() == CheckerDecision.DISAPPROVE)
+                request.setStatus(GovernanceRequestStatus.REJECTED);
+            else
+                execute(request);
+
+            requestRepository.save(request);
+
+            notifyMembers(request, "Maker request " + request.getStatus().name().toLowerCase(), user);
+        }
+        return request;
+    }
+
+    private void execute(GovernanceRequest r) {
+        Map<String,String> p = r.getParameters();
+        Chama chama = r.getChama();
+        ChamaRules rules = rulesRepository.findByChama(chama).orElseThrow();
+        switch (r.getAction()) {
+            case CREATE_GROUP_WALLET -> {
+                WalletResponse lw = lightningWalletService.createUserWallet(chama.getName() + " group wallet");
+                Map<String,String> lightning = new HashMap<>();
+                lightning.put("id", lw.id()); lightning.put("walletName", lw.name());
+                lightning.put("adminkey", lw.adminkey()); lightning.put("inkey", lw.inkey());
+                lightning.put("invoice_key", lw.invoice_key()); lightning.put("currency", lw.currency());
+                walletRepository.save(Wallet.builder().walletType(WalletType.CHAMA_GROUP)
+                        .ownerReference(chama.getChamaReference()).chama(chama).balanceSats(0L).lightning(lightning)
+                        .targetAmountSats(longParam(p, "targetAmountSats")).walletPurpose(p.getOrDefault("purpose", "Chama group wallet"))
+                        .active(true).build());
+            }
+            case WITHDRAW_GROUP_WALLET -> {
+                Wallet wallet = groupWallet(chama, p);
+                long amount = longParam(p, "amountSats");
+                if (wallet.getBalanceSats() < amount) throw new IllegalStateException("Insufficient group wallet balance");
+                if (wallet.getLightning() == null || wallet.getLightning().get("adminkey") == null)
+                    throw new IllegalStateException("Group wallet has no Lightning credentials");
+                String destination = required(p, "destination");
+                if (Bolt11Utils.extractAmountSats(destination) != amount)
+                    throw new IllegalArgumentException("Invoice amount must equal amountSats");
+                if (Bolt11Utils.extractExpiry(destination).isBefore(ZonedDateTime.now()))
+                    throw new IllegalArgumentException("Destination invoice is expired");
+                lightningWalletService.payInvoice(wallet.getLightning().get("adminkey"), destination);
+                wallet.setBalanceSats(wallet.getBalanceSats() - amount);
+                walletRepository.save(wallet);
+            }
+            case REMOVE_MEMBER -> { ChamaMember m = member(chama, p); m.setStatus(MembershipStatus.REMOVED); memberRepository.save(m); }
+            case SUSPEND_MEMBER -> { ChamaMember m = member(chama, p); m.setStatus(MembershipStatus.SUSPENDED); memberRepository.save(m); }
+            case ISSUE_FINE -> fineRepository.save(ChamaFine.builder().chama(chama).member(member(chama,p))
+                    .amountSats(longParam(p,"amountSats")).reason(p.get("reason")).paid(false).build());
+            case CHANGE_CONTRIBUTION_AMOUNT -> { long v=longParam(p,"contributionAmount"); rules.setContributionAmount(v); chama.setContributionAmount(v); rulesRepository.save(rules); chamaRepository.save(chama); }
+            case CHANGE_MAX_MEMBERS -> { int v=Math.toIntExact(longParam(p,"maxMembers")); if(v < memberRepository.countByChama_ChamaReferenceAndStatus(chama.getChamaReference(), MembershipStatus.ACTIVE)) throw new IllegalArgumentException("maxMembers is below active member count"); chama.setMaxMembers(v); chamaRepository.save(chama); }
+            case SKIP_ROTATION_MEMBER -> { chama.setCurrentRotationIndex(chama.getCurrentRotationIndex()+1); chamaRepository.save(chama); }
+            case CHANGE_CHAMA_CONFIG -> applyConfig(chama, rules, p);
+        }
+        r.setStatus(GovernanceRequestStatus.EXECUTED);
+    }
+
+    private void applyConfig(Chama c, ChamaRules rules, Map<String,String> p) {
+        if (p.containsKey("description")) c.setDescription(p.get("description"));
+        if (p.containsKey("requiredApprovals")) rules.setRequiredApprovals(Math.toIntExact(longParam(p,"requiredApprovals")));
+        if (p.containsKey("dailyLimitSats")) rules.setDailyLimitSats(longParam(p,"dailyLimitSats"));
+        chamaRepository.save(c); rulesRepository.save(rules);
+    }
+    private ChamaMember activeMember(UUID chamaId, User u) {
+        return memberRepository
+            .findByChama_ChamaReferenceAndUser_UserReferenceAndStatus(chamaId,u.getUserReference(),MembershipStatus.ACTIVE)
+            .orElseThrow(() -> new SecurityException("Only active chama members may use governance"));
+    }
+
+    private ChamaMember member(Chama c, Map<String,String> p) { UUID id=UUID.fromString(required(p,"memberReference")); ChamaMember m=memberRepository.findById(id).orElseThrow(); if(!m.getChama().getChamaReference().equals(c.getChamaReference())) throw new IllegalArgumentException("Member is not in chama"); return m; }
+    private Wallet groupWallet(Chama c, Map<String,String> p) { return walletRepository.findByWalletReferenceAndChama_ChamaReferenceAndWalletTypeAndActiveTrue(UUID.fromString(required(p,"walletReference")),c.getChamaReference(),WalletType.CHAMA_GROUP).orElseThrow(); }
+
+    private long longParam(Map<String,String> p,String key) {
+        long value=Long.parseLong(required(p,key));
+        if(value<=0) throw new IllegalArgumentException(key+" must be positive");
+        return value;
+    }
+
+    private String required(Map<String,String> p,String key) { String value=p.get(key); if(value==null||value.isBlank()) throw new IllegalArgumentException(key+" is required"); return value; }
+
+    private void validateParameters(GovernanceAction a, Map<String,String> p) {
+        switch(a) {
+            case CREATE_GROUP_WALLET -> longParam(p,"targetAmountSats");
+            case WITHDRAW_GROUP_WALLET -> {
+                required(p,"walletReference");
+                longParam(p,"amountSats");
+                required(p,"destination");
+            }
+            case REMOVE_MEMBER, SUSPEND_MEMBER -> required(p,"memberReference");
+            case ISSUE_FINE -> {
+                required(p,"memberReference");
+                longParam(p,"amountSats");
+            }
+            case CHANGE_CONTRIBUTION_AMOUNT -> longParam(p,"contributionAmount");
+            case CHANGE_MAX_MEMBERS -> longParam(p,"maxMembers");
+            case SKIP_ROTATION_MEMBER -> required(p,"memberReference");
+            case CHANGE_CHAMA_CONFIG -> {
+                if(p.isEmpty()) throw new IllegalArgumentException("At least one config field is required");
+            }
+        }
+    }
+
+    private void notifyMembers(GovernanceRequest r,String subject,User actor) { memberRepository.findMembersByChamaAndStatus(r.getChama().getChamaReference(),MembershipStatus.ACTIVE).forEach(m -> notifications.notifyGovernance(m.getUser(),r.getChama(),subject,r.getAction().name(),actor.getUsername())); }
+}

--- a/chamavault/src/main/java/com/dada_labs_two/chamavault/users/services/ProfileActionService.java
+++ b/chamavault/src/main/java/com/dada_labs_two/chamavault/users/services/ProfileActionService.java
@@ -217,9 +217,7 @@ public class ProfileActionService {
               Visibility: %s
               Current rotation: %d
             
-            We've also set up a Lightning wallet for your Chama. This
-            wallet can be used for pooled Chama funds and other group
-            transactions.
+            %s
             
             Your Chama is now ready for you to start inviting members
             and building together. 
@@ -235,10 +233,54 @@ public class ProfileActionService {
                 chama.getContributionAmount(),
                 chama.getMaxMembers(),
                 chama.getVisibility(),
-                chama.getCurrentRotationIndex()
+                chama.getCurrentRotationIndex(),
+                wallet == null
+                        ? "No group wallet was requested. Members can create one later through governance."
+                        : "We've also set up a Lightning group wallet with a target of %,d sats.".formatted(wallet.getTargetAmountSats())
         );
 
         sendNotification(creator, subject, body);
+    }
+
+    public void notifyGroupWalletContribution(User contributor, Chama chama, long amount, long total, Long target) {
+        String progress = target == null ? "No target configured" : "Target: %,d sats (%,d remaining)"
+                .formatted(target, Math.max(0, target - total));
+        sendNotification(contributor, "Contribution received for " + chama.getName(), """
+                Hi %s,
+
+                Your contribution of %,d sats to %s was recorded.
+                Total contributed: %,d sats
+                %s
+
+                Thank you for contributing.
+                """.formatted(getDisplayName(contributor), amount, chama.getName(), total, progress));
+    }
+
+    public void notifyGovernance(User recipient, Chama chama, String subject, String action, String actor) {
+        sendNotification(recipient, subject + " - " + chama.getName(), """
+                Hi %s,
+
+                Governance update for %s:
+                Action: %s
+                Initiated/updated by: %s
+                Status: %s
+
+                Open ChamaVault to review the request.
+                """.formatted(getDisplayName(recipient), chama.getName(), action, actor, subject));
+    }
+
+    public void notifyContributionReminder(User member, ContributionCycle cycle) {
+        sendNotification(member, "Contribution reminder - " + cycle.getChama().getName(), """
+                Hi %s,
+
+                Your %,d sats contribution for rotation %d of %s is still outstanding.
+                Due: %s
+                Current group total: %,d of %,d sats
+
+                Please contribute before the due date.
+                """.formatted(getDisplayName(member), cycle.getContributionAmount(), cycle.getRotationIndex(),
+                cycle.getChama().getName(), cycle.getEndAt(), cycle.getCurrentTotalContributionAmount(),
+                cycle.getExpectedTotalContributionAmount()));
     }
 
     public void notifyJoinRequestReceived(

--- a/chamavault/src/main/java/com/dada_labs_two/chamavault/wallets/controllers/TransactionsController.java
+++ b/chamavault/src/main/java/com/dada_labs_two/chamavault/wallets/controllers/TransactionsController.java
@@ -7,6 +7,7 @@ import com.dada_labs_two.chamavault.wallets.dtos.MakeInvoicePaymentDTO;
 import com.dada_labs_two.chamavault.wallets.dtos.TransferToMpesaRequestDTO;
 import com.dada_labs_two.chamavault.wallets.models.Transaction;
 import com.dada_labs_two.chamavault.wallets.services.TransactionService;
+import com.dada_labs_two.chamavault.wallets.constants.TransactionCategory;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -50,8 +51,9 @@ public class TransactionsController {
     }
 
     @GetMapping("/invoice-preview")
-    ResponseEntity<InvoicePreviewDTO> invoicePreview(@RequestParam String invoiceHash) {
-        return ResponseEntity.ok(transactionService.invoicePreview(invoiceHash));
+    ResponseEntity<InvoicePreviewDTO> invoicePreview(@RequestParam String invoiceHash,
+                                                      @RequestParam(required = false) TransactionCategory category) {
+        return ResponseEntity.ok(transactionService.invoicePreview(invoiceHash, category));
     }
 
     @GetMapping("/find-by/{rotationIndex}")

--- a/chamavault/src/main/java/com/dada_labs_two/chamavault/wallets/dtos/InvoicePreviewDTO.java
+++ b/chamavault/src/main/java/com/dada_labs_two/chamavault/wallets/dtos/InvoicePreviewDTO.java
@@ -1,11 +1,16 @@
 package com.dada_labs_two.chamavault.wallets.dtos;
 
 import java.time.ZonedDateTime;
+import java.math.BigDecimal;
+import java.util.UUID;
 
 public record InvoicePreviewDTO(
         Long amountSats,
         ZonedDateTime expiry,
         String memo,
-        Long interimFeeSats
+        Long platformFeeSats,
+        Long totalSats,
+        BigDecimal feePercentage,
+        UUID feeRuleReference
 ) {
 }

--- a/chamavault/src/main/java/com/dada_labs_two/chamavault/wallets/models/Transaction.java
+++ b/chamavault/src/main/java/com/dada_labs_two/chamavault/wallets/models/Transaction.java
@@ -52,6 +52,9 @@ public class Transaction {
 
     private Long amountSats;
     private Long feeSats = 0L;
+    private Long platformFeeSats = 0L;
+    private Long networkFeeSats = 0L;
+    private UUID feeRuleReference;
 
     // LNbits payment_hash or internal transfer id
     @Column(unique = true)

--- a/chamavault/src/main/java/com/dada_labs_two/chamavault/wallets/models/Wallet.java
+++ b/chamavault/src/main/java/com/dada_labs_two/chamavault/wallets/models/Wallet.java
@@ -59,6 +59,9 @@ public class Wallet {
     @Column(nullable = false)
     private Long balanceSats = 0L;
 
+    /** Savings goal for a chama group wallet; null for wallets without a target. */
+    private Long targetAmountSats;
+
     private Long lnBitsbalanceSats = 0L;
 
     @Column(nullable = false)

--- a/chamavault/src/main/java/com/dada_labs_two/chamavault/wallets/repositories/WalletRepository.java
+++ b/chamavault/src/main/java/com/dada_labs_two/chamavault/wallets/repositories/WalletRepository.java
@@ -8,6 +8,8 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.jpa.repository.Lock;
+import jakarta.persistence.LockModeType;
 import org.springframework.data.repository.query.Param;
 
 import java.time.Instant;
@@ -19,6 +21,11 @@ public interface WalletRepository extends JpaRepository<Wallet, UUID> {
     Optional<Wallet> findByOwnerReferenceAndWalletRole(UUID ownerReference, WalletRole  walletRole);
     Page<Wallet> findAllByOwnerReference(Pageable pageable,  UUID ownerReference);
     List<Wallet> findAllByOwnerReference(UUID ownerReference);
+    Optional<Wallet> findByWalletReferenceAndChama_ChamaReferenceAndWalletTypeAndActiveTrue(
+            UUID walletReference, UUID chamaReference, WalletType walletType);
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("select w from Wallet w where w.walletReference=:walletReference and w.chama.chamaReference=:chamaReference and w.walletType=:walletType and w.active=true")
+    Optional<Wallet> findActiveChamaWalletForUpdate(UUID walletReference, UUID chamaReference, WalletType walletType);
 
     Optional<Wallet> findByOwnerReferenceAndWalletTypeAndChamaAndActive(UUID ownerReference, WalletType walletType,
                                                                Chama chama, Boolean active);

--- a/chamavault/src/main/java/com/dada_labs_two/chamavault/wallets/services/TransactionService.java
+++ b/chamavault/src/main/java/com/dada_labs_two/chamavault/wallets/services/TransactionService.java
@@ -14,6 +14,9 @@ import com.dada_labs_two.chamavault.users.repository.UserRepository;
 import com.dada_labs_two.chamavault.users.services.ProfileActionService;
 import com.dada_labs_two.chamavault.wallets.constants.TransactionSource;
 import com.dada_labs_two.chamavault.wallets.constants.TransactionType;
+import com.dada_labs_two.chamavault.wallets.constants.TransactionCategory;
+import com.dada_labs_two.chamavault.fees.dtos.FeeQuote;
+import com.dada_labs_two.chamavault.fees.services.FeeService;
 import com.dada_labs_two.chamavault.wallets.constants.WalletType;
 import com.dada_labs_two.chamavault.wallets.dtos.InvoicePreviewDTO;
 import com.dada_labs_two.chamavault.wallets.dtos.MakeInvoicePaymentDTO;
@@ -49,6 +52,7 @@ public class TransactionService {
     private final ContributionCycleRepository cycleRepository;
     private final UserRepository userRepository;
     private final WalletRepository walletRepository;
+    private final FeeService feeService;
 
     @Transactional
     public Transaction makeRotationalPayments(
@@ -149,6 +153,7 @@ public class TransactionService {
         }
 
         long amountSats = cycle.getContributionAmount();
+        FeeQuote platformFee = feeService.quote(TransactionCategory.CHAMA_CONTRIBUTION, amountSats);
 
         /* ---------- STEP 2.1: fundingWallet → contributorWallet ---------- */
 
@@ -189,6 +194,7 @@ public class TransactionService {
                         contributorWallet.getLightning().get("adminkey"),
                         beneficiaryInvoice
                 );
+        String feePaymentHash = feeService.collect(fundingWallet, platformFee);
 
         // Update the contribution cycle with the new contribution
         updateContributionCycle(cycle, contributorWallet, amountSats);
@@ -224,6 +230,10 @@ public class TransactionService {
                         .type(TransactionType.DEBIT)
                         .source(TransactionSource.LN_INVOICE)
                         .amountSats(amountSats)
+                        .category(TransactionCategory.CHAMA_CONTRIBUTION)
+                        .platformFeeSats(platformFee.platformFeeSats())
+                        .feeSats(platformFee.platformFeeSats())
+                        .feeRuleReference(platformFee.feeRuleReference())
                         .externalRef(paymentHash2)
                         .initiatedBy(contributor.getUserReference())
                         .counterpartyUser(
@@ -231,27 +241,31 @@ public class TransactionService {
                         )
                         .rotationIndex(cycle.getRotationIndex())
                         .memo("Contribution payment")
-                        .metadata(recordInternalMoves)
+                        .metadata(withFeeMetadata(recordInternalMoves, platformFee, feePaymentHash))
                         .occurredAt(ZonedDateTime.now())
                         .build()
         );
 
     }
 
-    public InvoicePreviewDTO invoicePreview(String beneficiaryInvoice) {
+    public InvoicePreviewDTO invoicePreview(String beneficiaryInvoice, TransactionCategory category) {
         Long amountSats = Bolt11Utils.extractAmountSats(beneficiaryInvoice);
         ZonedDateTime expiry = Bolt11Utils.extractExpiry(beneficiaryInvoice);
         String memo = Bolt11Utils.extractDescription(beneficiaryInvoice).orElse("making payment for invoice");
-        Long interimFeeSats = 7L;
-
-        return new InvoicePreviewDTO(amountSats, expiry, memo, interimFeeSats);
+        FeeQuote fee = feeService.quote(category == null ? TransactionCategory.INVOICE_PAYMENT : category, amountSats);
+        return new InvoicePreviewDTO(amountSats, expiry, memo, fee.platformFeeSats(), fee.totalSats(), fee.percentage(), fee.feeRuleReference());
     }
 
     public Transaction makeInvoicePayment(UUID payerWalletId, String beneficiaryInvoice) {
+        return makeInvoicePayment(payerWalletId, beneficiaryInvoice, TransactionCategory.INVOICE_PAYMENT);
+    }
+
+    private Transaction makeInvoicePayment(UUID payerWalletId, String beneficiaryInvoice, TransactionCategory category) {
         Wallet payerWallet = walletRepository.findById(payerWalletId).orElseThrow(() ->
                 new RuntimeException("Payer wallet not found"));
 
         Long amountSats = Bolt11Utils.extractAmountSats(beneficiaryInvoice);
+        FeeQuote platformFee = feeService.quote(category, amountSats);
         String description = Bolt11Utils.extractDescription(beneficiaryInvoice).orElse("making payment for invoice");
 
         String paymentHash2 =
@@ -259,6 +273,7 @@ public class TransactionService {
                         payerWallet.getLightning().get("adminkey"),
                         beneficiaryInvoice
                 );
+        String feePaymentHash = feeService.collect(payerWallet, platformFee);
 
         //sync receiver wallet
         syncSenderLnBitsWalletBalance(payerWallet);
@@ -283,18 +298,20 @@ public class TransactionService {
                         .type(TransactionType.DEBIT)
                         .source(TransactionSource.LN_INVOICE)
                         .amountSats(amountSats)
+                        .category(category)
                         .externalRef(paymentHash2)
-                        .feeSats(fees.feeSats())
+                        .networkFeeSats(fees.feeSats())
+                        .platformFeeSats(platformFee.platformFeeSats())
+                        .feeSats(Math.addExact(fees.feeSats(), platformFee.platformFeeSats()))
+                        .feeRuleReference(platformFee.feeRuleReference())
                         .initiatedBy(null)
                         .counterpartyUser(
                                 payerWallet.getOwnerReference()
                         )
                         .rotationIndex(null)
                         .memo(description)
-                        .metadata(Map.of(
-                                "paymentHash", paymentHash2,
-                                "feeSats", String.valueOf(fees.feeSats())
-                        ))
+                        .metadata(withFeeMetadata(new HashMap<>(Map.of("paymentHash", paymentHash2,
+                                "networkFeeSats", String.valueOf(fees.feeSats()))), platformFee, feePaymentHash))
                         .occurredAt(ZonedDateTime.now())
                         .build()
         );
@@ -321,7 +338,7 @@ public class TransactionService {
 
         MakeInvoicePaymentDTO makeInvoicePaymentDTO = new MakeInvoicePaymentDTO(payerWalletId, response.pr());
         Transaction transaction = makeInvoicePayment(makeInvoicePaymentDTO.payerWalletId(),
-                makeInvoicePaymentDTO.beneficiaryInvoice());
+                makeInvoicePaymentDTO.beneficiaryInvoice(), TransactionCategory.WITHDRAWAL);
 
 
         profileActionService.notifyOffRampPayment(
@@ -361,6 +378,7 @@ public class TransactionService {
             throw new RuntimeException("Withdrawal may not be permitted on CHAMA_GROUP wallets");
 
         Wallet recipientWallet = walletRepository.findById(recipientWalletId).orElseThrow(() -> new RuntimeException("Recipient wallet not found"));
+        FeeQuote platformFee = feeService.quote(TransactionCategory.WALLET_TRANSFER, amountSats);
 
         //create invoice on behalf of recipient, then make a payment on behalf of sender
         String recipientInvoice =
@@ -376,6 +394,7 @@ public class TransactionService {
                         senderWallet.getLightning().get("adminkey"),
                         recipientInvoice
                 );
+        String feePaymentHash = feeService.collect(senderWallet, platformFee);
         log.info("paymentHash2 successfully created for senderWallet wallet {}", senderWallet.getLightning().get("adminkey"));
 
         //Sync Wallets
@@ -389,6 +408,7 @@ public class TransactionService {
                         .type(TransactionType.CREDIT)
                         .source(TransactionSource.LN_INVOICE)
                         .amountSats(amountSats)
+                        .category(TransactionCategory.WALLET_TRANSFER)
                         .externalRef(paymentHash2)
                         .initiatedBy(senderWallet.getOwnerReference())
                         .counterpartyUser(recipientWallet.getOwnerReference())
@@ -406,12 +426,16 @@ public class TransactionService {
                         .type(TransactionType.DEBIT)
                         .source(TransactionSource.LN_INVOICE)
                         .amountSats(amountSats)
+                        .category(TransactionCategory.WALLET_TRANSFER)
+                        .platformFeeSats(platformFee.platformFeeSats())
+                        .feeSats(platformFee.platformFeeSats())
+                        .feeRuleReference(platformFee.feeRuleReference())
                         .externalRef(paymentHash2)
                         .initiatedBy(senderWallet.getOwnerReference())
                         .counterpartyUser(recipientWallet.getOwnerReference())
                         .rotationIndex(null)
                         .memo(memo)
-                        .metadata(new HashMap<>())
+                        .metadata(withFeeMetadata(new HashMap<>(), platformFee, feePaymentHash))
                         .occurredAt(ZonedDateTime.now())
                         .build()
         );
@@ -520,5 +544,13 @@ public class TransactionService {
     public Page<Transaction> searchTransactions(Map<String, String> filters, Pageable page) {
         Specification<Transaction> spec = TransactionSpecificationBuilder.build(filters);
         return transactionRepository.findAll(spec, page);
+    }
+
+    private Map<String,String> withFeeMetadata(Map<String,String> metadata, FeeQuote fee, String feePaymentHash) {
+        metadata.put("platformFeeSats", String.valueOf(fee.platformFeeSats()));
+        metadata.put("feePercentage", fee.percentage().toPlainString());
+        if (fee.feeRuleReference() != null) metadata.put("feeRuleReference", fee.feeRuleReference().toString());
+        if (feePaymentHash != null) metadata.put("feePaymentHash", feePaymentHash);
+        return metadata;
     }
 }


### PR DESCRIPTION
- added platform fees
- added group wallets and group wallet contributions & notifications
- Added governance actions
- - Optional group-wallet creation using:
  - `createGroupWallet`
  - `groupWalletTargetAmountSats`
- Member-only group-wallet contributions funded through the member’s Lightning wallet.
- Contribution ledger, target progress, remaining amount, and confirmation emails.
- Configurable invite expiry, defaulting to seven days.
- Invite creation now uses the authenticated user and permits any active chama member.
- Maker/checker governance with:
  - Configurable approval threshold, supporting 2-of-3.
  - No maker self-approval.
  - One vote per checker.
  - Approval and disapproval voting.
  - Notifications to active members.
- Supported governance actions:
  - Group-wallet withdrawal
  - Group-wallet creation
  - Member removal or suspension
  - Fine issuance
  - Contribution amount changes
  - Maximum member changes
  - Rotation skipping
  - General chama configuration changes
- Automated contribution reminders for members with outstanding active-rotation contributions.
- Pessimistic wallet locking to prevent concurrent contribution balance updates.
- HTTP 403 handling for membership/ownership authorization failures.